### PR TITLE
Optional cutadapt

### DIFF
--- a/rules/qc/qc.rules
+++ b/rules/qc/qc.rules
@@ -35,8 +35,7 @@ rule custom_removal:
             """)
         else:
             shell("""
-            ln -s {input.r1} {output.r1} \
-            ln -s {input.r2} {output.r2}
+            ln -s {input.r1} {output.r1} && ln -s {input.r2} {output.r2}
             """)
 
         

--- a/rules/qc/qc.rules
+++ b/rules/qc/qc.rules
@@ -14,16 +14,22 @@ rule custom_removal:
     output:
         r1 = str(QC_FP/'cutadapt'/'{sample}_R1.fastq'),
         r2 = str(QC_FP/'cutadapt'/'{sample}_R2.fastq')
-    params:
-        fwd_adapters = " ".join(expand(
-            "-b {adapter}", adapter=Cfg['qc']['fwd_adapters']))
-        rev_adapters = " ".join(expand(
-            "-B {adapter}", adapter=Cfg['qc']['rev_adapters']))
     run:
-        if Cfg['qc']['fwd_adapters'] or Cfg['qc']['rev_adapters']:
+        fwd_adapters = Cfg['qc']['fwd_adapters']
+        rev_adapters = Cfg['qc']['rev_adapters']
+        if fwd_adapters or rev_adapters:
+            overlap = float('inf')
+            if fwd_adapters:
+                overlap = min(min(len(a) for a in fwd_adapters), overlap)
+                fwd_adapter_str = " ".join(expand(
+                    "-b {adapter}", adapter=Cfg['qc']['fwd_adapters']))
+            if rev_adapters:
+                overlap = min(min(len(a) for a in rev_adapters), overlap)
+                rev_adapter_str = " ".join(expand(
+                    "-B {adapter}", adapter=Cfg['qc']['rev_adapters']))
             shell("""
-            cutadapt --discard-trimmed\
-            {params.fwd_adapters} {params.rev_adapters} \
+            cutadapt --discard-trimmed -O {overlap} \
+            {fwd_adapter_str} {rev_adapter_str} \
             -o {output.r1} -p {output.r2} \
             {input.r1} {input.r2}
             """)

--- a/rules/qc/qc.rules
+++ b/rules/qc/qc.rules
@@ -16,16 +16,23 @@ rule custom_removal:
         r2 = str(QC_FP/'cutadapt'/'{sample}_R2.fastq')
     params:
         fwd_adapters = " ".join(expand(
-            "-b {adapter}", adapter=Cfg['qc']['fwd_adapters'])),
+            "-b {adapter}", adapter=Cfg['qc']['fwd_adapters']))
         rev_adapters = " ".join(expand(
             "-B {adapter}", adapter=Cfg['qc']['rev_adapters']))
-    shell:
-        """
-        cutadapt --discard-trimmed\
-        {params.fwd_adapters} {params.rev_adapters} \
-        -o {output.r1} -p {output.r2} \
-        {input.r1} {input.r2}
-        """
+    run:
+        if Cfg['qc']['fwd_adapters'] or Cfg['qc']['rev_adapters']:
+            shell("""
+            cutadapt --discard-trimmed\
+            {params.fwd_adapters} {params.rev_adapters} \
+            -o {output.r1} -p {output.r2} \
+            {input.r1} {input.r2}
+            """)
+        else:
+            shell("""
+            ln -s {input.r1} {output.r1} \
+            ln -s {input.r2} {output.r2}
+            """)
+
         
 rule trimmomatic:
     input:

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -62,3 +62,13 @@ grep 'NC_006347.1' $TEMPDIR/sunbeam_output/annotation/summary/dummybfragilis.tsv
 
 # Check targets
 python tests/find_targets.py --prefix $TEMPDIR/sunbeam_output tests/targets.txt 
+
+# Bugfix/feature tests: add as needed
+
+# Fix for #38: Make Cutadapt optional
+# -- Remove adapter sequences and check to make sure qc proceeds correctly
+sed 's/adapters: \[.*\]/adapters: \[\]/g' $TEMPDIR/tmp_config.yml > $TEMPDIR/tmp_config_nocutadapt.yml
+rm -rf $TEMPDIR/sunbeam_output/qc
+snakemake --configfile=$TEMPDIR/tmp_config_nocutadapt.yml all_decontam
+[ -f $TEMPDIR/sunbeam_output/qc/decontam/dummyecoli_R1.fastq ]
+[ -f $TEMPDIR/sunbeam_output/qc/decontam/dummyecoli_R2.fastq ]


### PR DESCRIPTION
- Cutadapt now only executes if the forward and/or reverse adapters are specified in the config file, otherwise it symlinks the files into the `qc/cutadapt` directory
- Cutadapt now requires overlap equal to the length of the smallest adapters specified before removing a read to reduce incidences of false read removal