### PR TITLE
fix vsearch empty fasta error

### DIFF
--- a/rules/assembly/assembly.rules
+++ b/rules/assembly/assembly.rules
@@ -77,10 +77,15 @@ rule final_filter:
         filename = os.path.basename(input[0])
         shell(
         """
-        vsearch --sortbylength {input} \
-        --relabel {filename} --minseqlength {params.len} \
-        --output {input}.{params.len}f &> {log} && \
-        cp {input}.{params.len}f {output}
+        if [ -s {input} ]
+        then
+            vsearch --sortbylength {input} \
+            --relabel {filename} --minseqlength {params.len} \
+            --output {input}.{params.len}f &> {log} && \
+            cp {input}.{params.len}f {output}
+        else
+            cp {input} {output} &> {log}
+        fi
         """)
 
 rule clean_assembly:


### PR DESCRIPTION
for negative control samples, there might be no contigs assembled. and for empty cap3-contigs.fa case, vsearch (final_filter rule) gave error: Unable to read from file (cap3-contigs.fa).
Fixed: copy cap3-contigs.fa as the output of the rule final_filter