### PR TITLE
add non temp test dir option

### DIFF
--- a/tests/test.sh
+++ b/tests/test.sh
@@ -30,6 +30,7 @@ function cleanup {
 # Calls cleanup when the script exits
 if [ $# -ne 1 ]; then
     trap cleanup EXIT
+fi
 
 pushd tests
 # Copy data into the temporary directory

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -9,9 +9,9 @@ export PATH=$PATH:$HOME/miniconda3/bin
 ROOT=`pwd`
 
 if [ $# -ne 1 ]; then
-    echo "Write test output to temp file"
     TEMPDIR=`mktemp -d`
 else
+    echo "Write sunbeam test result to provided path"
     TEMPDIR="$1"
 fi
 
@@ -28,7 +28,8 @@ function cleanup {
 }
 
 # Calls cleanup when the script exits
-#trap cleanup EXIT
+if [ $# -ne 1 ]; then
+    trap cleanup EXIT
 
 pushd tests
 # Copy data into the temporary directory

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -5,13 +5,20 @@ set -e # Stop on errors
 # Ensure we can activate the environment
 export PATH=$PATH:$HOME/miniconda3/bin
 
+# Set up paths
+ROOT=`pwd`
+
+if [ $# -ne 1 ]; then
+    echo "Write test output to temp file"
+    TEMPDIR=`mktemp -d`
+else
+    TEMPDIR="$1"
+fi
+
 # Activate the sunbeam environment
 source activate sunbeam
 command -v snakemake
 
-# Set up paths
-ROOT=`pwd`
-TEMPDIR=`mktemp -d`
 mkdir -p $TEMPDIR/data_files
 
 function cleanup {
@@ -21,7 +28,7 @@ function cleanup {
 }
 
 # Calls cleanup when the script exits
-trap cleanup EXIT
+#trap cleanup EXIT
 
 pushd tests
 # Copy data into the temporary directory


### PR DESCRIPTION
Add the option for test.sh suggested by @kylebittinger 
 -- if a directory is passed to the test.sh script, then the test output should be written there. Otherwise, the output should be written to a temp file and removed, as it is now.

Not sure about the "trap cleanup EXIT". Since the point is to inspect the intermediate files, we would not want cleanup. Yet we might want to keep this for the tmp file though... Any suggestions?

