### PR TITLE
Config file

### DIFF
--- a/sunbeamlib/initialize.py
+++ b/sunbeamlib/initialize.py
@@ -1,7 +1,7 @@
 import os
 import sys
+import argparse
 
-from argparse import ArgumentParser
 from pathlib import Path
 
 from sunbeamlib.config import create_blank_config
@@ -21,7 +21,7 @@ def main():
 
     conda_fp = _find_conda_fp()
      
-    parser = ArgumentParser(
+    parser = argparse.ArgumentParser(
         "init", description="Initialize a new sunbeam project")
     parser.add_argument("project_fp", help="Project root directory")
     parser.add_argument(
@@ -31,9 +31,12 @@ def main():
         "--conda_fp", default=conda_fp, type=Path,
         help="path to conda (default: %(default)s)"
     )
+    parser.add_argument(
+        "--custom_configfile_fp", help="Custom config file absolute directory", 
+        type=argparse.FileType("r"), default=None)
 
     args = parser.parse_args()
-
+    
     if not args.conda_fp or not args.conda_fp.exists():
         raise SystemExit((
             "Error: conda installation could not be found at '{conda_fp}'. " 
@@ -42,8 +45,18 @@ def main():
     else:
         args.conda_fp = args.conda_fp.absolute()
 
-    config = create_blank_config(
-        args.conda_fp, args.project_fp, template=args.server)
     
+    print(args.conda_fp)
+    print(args.project_fp)
+    if args.custom_configfile_fp is None:
+        config = create_blank_config(
+            args.conda_fp, args.project_fp, template=args.server)
+    elif os.path.isfile(args.custom_configfile_fp.name):
+        with open(args.custom_configfile_fp.name, 'r') as f:
+            config = f.read()
+    else:
+        raise SystemExit(
+            "Specify a valid path to custom config file --custom_configfile_fp.")
+ 
     sys.stdout.write(config)
 

--- a/sunbeamlib/initialize.py
+++ b/sunbeamlib/initialize.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import argparse
+import yaml
 
 from pathlib import Path
 
@@ -32,8 +33,9 @@ def main():
         help="path to conda (default: %(default)s)"
     )
     parser.add_argument(
-        "--custom_configfile_fp", help="Custom config file absolute directory", 
-        type=argparse.FileType("r"), default=None)
+        "--template", default=None, 
+        help="Path to custom config file template, in YAML format", 
+        type=argparse.FileType("r"))
 
     args = parser.parse_args()
     
@@ -45,15 +47,11 @@ def main():
     else:
         args.conda_fp = args.conda_fp.absolute()
 
-    if args.custom_configfile_fp is None:
+    if args.template is None:
         config = create_blank_config(
             args.conda_fp, args.project_fp, template=args.server)
-    elif os.path.isfile(args.custom_configfile_fp.name):
-        with open(args.custom_configfile_fp.name, 'r') as f:
-            config = f.read()
     else:
-        raise SystemExit(
-            "Specify a valid path to custom config file --custom_configfile_fp.")
- 
+        config = args.template.read() 
     sys.stdout.write(config)
 
+main()

--- a/sunbeamlib/initialize.py
+++ b/sunbeamlib/initialize.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import argparse
-import yaml
 
 from pathlib import Path
 

--- a/sunbeamlib/initialize.py
+++ b/sunbeamlib/initialize.py
@@ -45,9 +45,6 @@ def main():
     else:
         args.conda_fp = args.conda_fp.absolute()
 
-    
-    print(args.conda_fp)
-    print(args.project_fp)
     if args.custom_configfile_fp is None:
         config = create_blank_config(
             args.conda_fp, args.project_fp, template=args.server)


### PR DESCRIPTION
add an option for sunbeam_init --custom_configfile_fp: if this argument is provided, then it will be used as the template for generating config file for snakemake. This feature will be very helpful for testing purpose for newly added rules. 