### PR TITLE
Add mapping rules using bowtie2 and IGV

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
+before_install:
+  - sudo apt-get install xdotool
 install:
-  - bash install.sh
+  - bash install.sh sunbeam anaconda_log.txt
   - bash install_igv.sh
 script: source tests/test.sh
 #test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
-install: bash install.sh
+install:
+  - bash install.sh
+  - bash install_igv.sh
 script: source tests/test.sh
 #test

--- a/Snakefile
+++ b/Snakefile
@@ -10,12 +10,12 @@ import sys
 import yaml
 import configparser
 from pprint import pprint
-from pathlib import Path
+from pathlib import Path, PurePath
 
 from snakemake.utils import update_config, listfiles
 from snakemake.exceptions import WorkflowError
 
-from sunbeamlib import build_sample_list
+from sunbeamlib import build_sample_list, read_seq_ids
 from sunbeamlib.config import *
 from sunbeamlib.reports import *
 
@@ -31,6 +31,9 @@ if not config:
 Cfg = check_config(config)
 Blastdbs = process_databases(Cfg['blastdbs'])
 Samples = build_sample_list(Cfg['all']['data_fp'], Cfg['all']['filename_fmt'], Cfg['all']['exclude'])
+
+GenomeFiles = [f for f in Cfg['mapping']['genomes_fp'].glob('*.fasta')]
+GenomeSegments = {PurePath(g.name).stem: read_seq_ids(Cfg['mapping']['genomes_fp'] / g) for g in GenomeFiles}
 
 # ---- Change your workdir to output_fp
 workdir: str(Cfg['all']['output_fp'])

--- a/install.sh
+++ b/install.sh
@@ -5,10 +5,11 @@ set -e
 PREFIX=$HOME/miniconda3
 
 SUNBEAM_ENV_NAME=${1-sunbeam}
+OUTPUT=${2-/dev/stdout}
 
 install_conda () {
     wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-    bash Miniconda3-latest-Linux-x86_64.sh -b -p $PREFIX
+    bash Miniconda3-latest-Linux-x86_64.sh -b -p $PREFIX >> $OUTPUT
     export PATH=$PATH:$PREFIX/bin
     command -v conda >/dev/null 2>&1 || { echo "Conda still isn't on the path, try installing manually"; exit 1; }
 }
@@ -21,10 +22,10 @@ conda config --add channels eclarke
 
 # Don't create the enviroment if it already exists
 conda env list | grep -Fxq $SUNBEAM_ENV_NAME || {
-    conda create --name=$SUNBEAM_ENV_NAME --file=requirements.txt --yes;
+    conda create --name=$SUNBEAM_ENV_NAME --file=requirements.txt --yes >> $OUTPUT
     source activate $SUNBEAM_ENV_NAME
-    pip install .
-    pip install git+https://github.com/eclarke/decontam.git
+    pip install . >> $OUTPUT
+    pip install git+https://github.com/eclarke/decontam.git >> $OUTPUT
     echo "Sunbeam successfully installed.";
 }
 

--- a/install_igv.sh
+++ b/install_igv.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+# Quick install of IGV into the home directory.
+# $HOME/IGV will still need to be separately added to PATH for this to work.
+install_igv() {
+    DIR=$HOME
+    IGV_VER=2.3.68
+    wget http://data.broadinstitute.org/igv/projects/downloads/IGV_${IGV_VER}.zip
+    unzip IGV_${IGV_VER}.zip -d $DIR
+    ln -s IGV_$IGV_VER $DIR/IGV
+    # A symlink will confuse igv.sh so I'm using a wrapper script instead
+    echo -e "#!/bin/bash\ncd $DIR/IGV && ./igv.sh \$@" > $DIR/IGV/igv
+    chmod +x $DIR/IGV/igv
+    export PATH=$DIR/IGV:$PATH
+    command -v igv >/dev/null 2>&1 || { echo "IGV still isn't on the path, try installing manually"; exit 1; }
+}
+
+command -v igv >/dev/null 2>&1 || { echo "IGV not installed, installing now"; install_igv; }

--- a/install_igv.sh
+++ b/install_igv.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 set -e
 
-# Quick install of IGV into the home directory.
-# $HOME/IGV will still need to be separately added to PATH for this to work.
+# Quick install of IGV into the sunbeam/local directory.
+# For use in Sunbeam the IGV path should be specified in the mapping section of
+# the configuration file as 'igv_fp'.
 install_igv() {
-    DIR=$HOME
+    DIR=$(readlink -f $(dirname $BASH_SOURCE))/local
     IGV_VER=2.3.68
     wget http://data.broadinstitute.org/igv/projects/downloads/IGV_${IGV_VER}.zip
     unzip IGV_${IGV_VER}.zip -d $DIR

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ kraken-biom
 pear
 vsearch
 bwa
+bowtie2
 jellyfish=1.1.11=1
 cutadapt
 pysam

--- a/rules/mapping/bowtie.rules
+++ b/rules/mapping/bowtie.rules
@@ -1,19 +1,6 @@
 # -*- mode: Snakemake -*-
-"""
-Requirements for the igv functions:
- * IGV
- * xvfb
- * xdotool
-"""
 
-from pathlib import Path, PurePath
-import socket
-import time
-import tempfile
-import subprocess
-import os
-import re
-from sunbeamlib import index_files
+from sunbeamlib import index_files, igv
 
 # Generate Snakemake template strings for a few commonly-used parameters below
 INDICES = index_files('{genome}', Cfg['mapping']['genomes_fp'])
@@ -86,86 +73,4 @@ rule igv_snapshot:
     output:
         png=str(MAPPING_FP/"{genome}-{segment}.alignment.png")
     run:
-        igv_render(input.genome, input.bams, output.png, params.segment, input.igv_fp, "script")
-
-
-### IGV Helper Functions
-
-def igv_render(genome, bams, imagefile, seqID=None, igv_fp="igv", method="script"):
-        """ Render an alignment to an image, given a genome and bam files.
-
-        genome: path to a fasta file
-        bams: list of path to a sorted, indexed bam file
-        imagefile: path to the image to save
-        seqID: (optional) sequence identifier to load from genome
-        igv_fp: (optional) path to IGV executable
-        method: (optional) method for controlling IGV process: "script" or "socket"
-
-        The image file may be smaller than expected.  See
-        igv_render_socket_nonblocking() for an attempt to enlarge the window
-        before saving the image.
-        """
-        input_paths = [str(Path(bam).resolve()) for bam in bams]
-        genome_path = str(Path(genome).resolve())
-        output_path = str( Path('.').resolve() / Path(imagefile) )
-        genome_cmd = 'genome ' + genome_path
-        if seqID:
-            genome_cmd += "\ngoto %s" % seqID
-        igvcommands = ['new',
-            genome_cmd,
-            'load ' + ','.join(input_paths),
-            'collapse',
-            'snapshot ' + output_path,
-            'exit']
-        if method == "script":
-            igvprefs = ["GENOME_LIST=;%s" % genome_path,
-                "DEFAULT_GENOME_KEY=%s" % genome_path]
-            _igv_control_script(igvcommands, igv_fp, igvprefs)
-        elif method == "socket":
-            _igv_control_socket(igvcommands, igv_fp)
-        else:
-            raise ValueError("method should be 'script' or 'socket', not '%s'" % method)
-
-def _igv_control_script(igvcommands, igv_fp, igvprefs):
-        igvscript = tempfile.NamedTemporaryFile()
-        igvscript.writelines(map(lambda x: bytes(x+'\n', 'ascii'), igvcommands))
-        igvscript.flush()
-        # If previous genome files listed in IGV's preferences are no longer
-        # available, IGV will throw a null pointer exception at startup and
-        # batch commands will fail.  So, we'll use a preferences override file
-        # to list the genome file used here.  (This is probably an IGV bug.  We
-        # should see if it happens in the latest release.)
-        # I've also tried setting IGV.Bounds in an attempt to make the window
-        # larger, but it doesn't seem to have any effect.
-        igvprefsfile = tempfile.NamedTemporaryFile()
-        igvprefstext = map(lambda x: bytes(x+'\n', 'ascii'), igvprefs)
-        igvprefsfile.writelines(igvprefstext)
-        igvprefsfile.flush()
-        shell("xvfb-run -s '-screen 1 1920x1080x24' %s -o %s -b %s" % (igv_fp, igvprefsfile.name, igvscript.name))
-
-def _igv_control_socket(igvcommands, igv_fp):
-        # Start up IGV.  Use a port between 10000 and the max available, based
-        # on the PID of this process.  (TODO is using this pid safe?)
-        port = 10000 + os.getpid()%(2**16-10000)
-        xauth = "/tmp/xauth-%d" % os.getpid()
-        igv = subprocess.Popen(["xvfb-run", "-l", "-f" , xauth, "-s", "-screen 1 1920x1080x24", str(igv_fp), "-p", str(port)])
-
-        # Connect to running IGV
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        while True:
-            try:
-                s.connect(('localhost', port))
-                break
-            except ConnectionRefusedError:
-                time.sleep(0.5)
-
-        # Based on http://unix.stackexchange.com/questions/5999/ :
-        # This should make the window as large as the virtual X display, but in
-        # practice my screenshots aren't going over 1280 x 1296.
-        display = ":99"
-        shell("DISPLAY="+display+" XAUTHORITY="+xauth+" xdotool search --onlyvisible --name IGV windowsize --sync 100% 100%")
-
-        # Generate screenshot
-        s.sendall(bytes('\n'.join(igvcommands), 'ascii'))
-        s.close()
-        igv.wait()
+        igv.render(input.genome, input.bams, output.png, params.segment, input.igv_fp, "script")

--- a/rules/mapping/bowtie.rules
+++ b/rules/mapping/bowtie.rules
@@ -1,66 +1,180 @@
 # -*- mode: Snakemake -*-
+"""
+Requirements for the igv functions:
+ * IGV
+ * xvfb
+ * xdotool
+"""
 
-def bt2_index_files(genome, idx_fp):
-    fwd = expand('{idx_fp}/{genome}.{index}.bt2',
-                 genome=genome,
-                 idx_fp=idx_fp,
-                 index=range(1,5))
-    rev = expand('{idx_fp}/{genome}.rev.{index}.bt2',
-                 genome=genome,
-                 idx_fp=idx_fp,
-                 index=range(1,3))
-    return fwd + rev
+from pathlib import Path, PurePath
+import socket
+import time
+import tempfile
+import subprocess
+import os
+import re
+from sunbeamlib import index_files
 
-rule bt2_index:
-    output:
-        bt2_index_files('{genome}', Cfg['mapping']['genomes_fp'])
+# Generate Snakemake template strings for a few commonly-used parameters below
+INDICES = index_files('{genome}', Cfg['mapping']['genomes_fp'])
+GENOME = str(Cfg['mapping']['genomes_fp'] / "{genome}.fasta")
+
+rule bowtie2_all:
+    # Create these three sets of files specifically:
+    # * indexed sorted bam files
+    # * bcf files
+    # * screenshots of alignments made with IGV
+    input: TARGET_MAPPING
+
+rule bowtie2_build:
+    message: "Creating bowtie2 index files for {input}"
+    input: GENOME
+    output: INDICES
     params:
-        idx_fp = str(Cfg['mapping']['genomes_fp'])
-    shell:
-        "bowtie2-build {params.idx_fp}/{wildcards.genome}.fa {params.idx_fp}/{wildcards.genome}"
+        genome="{genome}",
+        index_fp=str(Cfg['mapping']['genomes_fp'])
+    shell: "cd {params.index_fp} && bowtie2-build {input} {params.genome}"
 
-rule bt2_map_contigs:
+rule bowtie2_align:
+    message: "Aligning {wildcards.sample} reads to genome {wildcards.genome}"
     input:
-        lambda wildcards: bt2_index_files(wildcards.genome, Cfg['mapping']['genomes_fp']),
-        r1 = str(QC_FP/'decontam'/'{sample}_R1.fastq'),
-        r2 = str(QC_FP/'decontam'/'{sample}_R2.fastq')
-    output:
-        temp(str(MAPPING_FP/'{genome}'/'{sample}/reads.sam'))
+        rp = expand(str(Cfg['all']['data_fp'] / Cfg['all']['filename_fmt']), rp = ['R1','R2'], sample="{sample}"),
+        indices = INDICES
+    output: temp(str(MAPPING_FP/"{genome}-{sample}.sam"))
     params:
-        idx=str(Cfg['mapping']['genomes_fp']/'{genome}')
-    shell:
-        "bowtie2 -x {params.idx} -1 {input.r1} -2 {input.r2} -S {output} -p {Cfg[all][subcores]}"
+        genome="{genome}",
+        index_fp=str(Cfg['mapping']['genomes_fp'])
+    shell: "bowtie2 -x {params.index_fp}/{params.genome} -1 {input.rp[0]} -2 {input.rp[1]} -S {output}"
 
-rule sam_to_bam:
-    input: "{fname}.sam"
-    output: temp("{fname}.bam")
+rule samtools_view:
+    message: "Converting {wildcards.genome}-{wildcards.sample} alignment from SAM to BAM format with samtools"
+    input: str(MAPPING_FP/"{genome}-{sample}.sam")
+    output: str(MAPPING_FP/"{genome}-{sample}.bam")
     shell: "samtools view -bS {input} > {output}"
 
-rule sort_bam:
-    input: "{fname}.bam"
-    output: "{fname}.sorted.bam"
-    shell: "samtools sort -o {output} {input}"
+rule samtools_sort:
+    message: "Sorting {input} with samtools"
+    input: str(MAPPING_FP/"{genome}-{sample}.bam")
+    output: str(MAPPING_FP/"{genome}-{sample}.sorted.bam")
+    shell: "samtools sort {input} > {output}"
 
-rule index_bam:
-    input: "{fname}.sorted.bam"
-    output: "{fname}.sorted.bam.bai"
-    shell: "samtools index {input}"
+rule samtools_index:
+    message: "Indexing {input} with samtools"
+    input: str(MAPPING_FP/"{genome}-{sample}.sorted.bam")
+    output: str(MAPPING_FP/"{genome}-{sample}.sorted.bam.bai")
+    shell: "samtools index {input} {output}"
 
-rule bam_stats:
+rule samtools_mpileup:
+    message: "Calling variants for {input.bam} with samtools and bcftools"
     input:
-        bam="{fname}.sorted.bam",
-        bai="{fname}.sorted.bam.bai"
-    output: "{fname}.stats"
-    shell: "samtools stats {input.bam} > {output}"
+        bam = str(MAPPING_FP/"{genome}-{sample}.sorted.bam"),
+        genome = GENOME
+    output: str(MAPPING_FP/"{genome}-{sample}.raw.bcf")
+    shell: "samtools mpileup -gf {input.genome} {input.bam} | bcftools call -Ob -v -c - > {output}"
+
+# I'm creating each segment snapshot separate, but really it could be done in
+# one IGV run.  Can Snakemake handle that?
+rule igv_snapshot:
+    message: "Create an alignment image for {wildcards.genome}-{wildcards.segment} with IGV"
+    input:
+        genome = GENOME,
+        bams=expand(str(MAPPING_FP/"{{genome}}-{sample}.sorted.bam"), sample=Samples.keys()),
+        bais=expand(str(MAPPING_FP/"{{genome}}-{sample}.sorted.bam.bai"), sample=Samples.keys())
+    params:
+        segment="{segment}"
+    output:
+        png=str(MAPPING_FP/"{genome}-{segment}.alignment.png")
+    run:
+        igv_render_script(input.genome, input.bams, output.png, params.segment)
 
 
-rule _map_all:
-    input:
-        expand(
-            str(MAPPING_FP/'t_gondii'/'{sample}'/'reads.stats'),
-            sample=Samples.keys())
-           
-rule _test_bt2:
-    input:
-        expand(str(MAPPING_FP/'t_gondii_COUG'/'{sample}/reads.stats'),
-               sample='Sample2c_S30')
+### IGV Helper Functions
+
+
+def igv_render_script(genome, bams, imagefile, seqID=None):
+        """ Render an alignment to an image, given a genome and bam files.
+
+        genome: path to a fasta file
+        bams: list of path to a sorted, indexed bam file
+        imagefile: path to the image to save
+        seqID: (optional) sequence identifier to load from genome
+
+        The image file may be smaller than expected.  See
+        igv_render_socket_nonblocking() for an attempt to enlarge the window
+        before saving the image.
+        """
+        input_paths = [str(Path(bam).resolve()) for bam in bams]
+        genome_path = str(Path(genome).resolve())
+        output_path = str( Path('.').resolve() / Path(imagefile) )
+        genome_cmd = 'genome ' + genome_path
+        if seqID:
+            genome_cmd += "\ngoto %s" % seqID
+        igvcommands = ['new',
+            genome_cmd,
+            'load ' + ','.join(input_paths),
+            'collapse',
+            'snapshot ' + output_path,
+            'exit']
+        igvscript = tempfile.NamedTemporaryFile()
+        igvscript.writelines(map(lambda x: bytes(x+'\n', 'ascii'), igvcommands))
+        igvscript.flush()
+        # If previous genome files listed in IGV's preferences are no longer
+        # available, IGV will throw a null pointer exception at startup and
+        # batch commands will fail.  So, we'll use a preferences override file
+        # to list the genome file used here.  (This is probably an IGV bug.  We
+        # should see if it happens in the latest release.)
+        # I've also tried setting IGV.Bounds in an attempt to make the window
+        # larger, but it doesn't seem to have any effect.
+        igvprefsfile = tempfile.NamedTemporaryFile()
+        igvprefs = ["GENOME_LIST=;%s" % genome_path,
+            "DEFAULT_GENOME_KEY=%s" % genome_path]
+        igvprefstext = map(lambda x: bytes(x+'\n', 'ascii'), igvprefs)
+        igvprefsfile.writelines(igvprefstext)
+        igvprefsfile.flush()
+        shell("xvfb-run -s '-screen 1 1920x1080x24' igv -o %s -b %s" % (igvprefsfile.name, igvscript.name))
+
+def igv_render_socket_nonblocking(genome, bams, imagefile):
+        input_paths = [str(Path(bam).resolve()) for bam in bams]
+        genome_path = str(Path(genome).resolve())
+        output_path = str( Path('.').resolve() / Path(imagefile) )
+
+        # Start up IGV.  Use a port between 10000 and the max available, based
+        # on the PID of this process.  (TODO is using this pid safe?)
+        port = 10000 + os.getpid()%(2**16-10000)
+        xauth = "/tmp/xauth-%d" % os.getpid()
+        igv = subprocess.Popen(["xvfb-run", "-l", "-f" , xauth, "-s", "-screen 1 1920x1080x24", "igv", "-p", str(port)])
+
+        # Connect to running IGV
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        while True:
+            try:
+                s.connect(('localhost', port))
+                break
+            except ConnectionRefusedError:
+                time.sleep(0.5)
+
+        # Based on http://unix.stackexchange.com/questions/5999/ :
+        # This should make the window as large as the virtual X display, but in
+        # practice my screenshots aren't going over 1280 x 1296.
+        display = ":99"
+        shell("DISPLAY="+display+" XAUTHORITY="+xauth+" xdotool search --onlyvisible --name IGV windowsize --sync 100% 100%")
+
+        # Generate screenshot
+        commands = ['new', 'genome ' + genome_path, 'load ' + ','.join(input_paths), 'collapse', 'snapshot ' + output_path, 'exit']
+        s.sendall(bytes('\n'.join(commands), 'ascii'))
+        s.close()
+        igv.wait()
+
+# NOTE: this version assumes an already-running IGV configured to allow access
+# on the default port (60151), so it's not as useful for automation.
+def igv_render_socket(genome, bams, imagefile):
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.connect(('localhost', 60151))
+        input_paths = [str(Path(bam).resolve()) for bam in bams]
+        genome_path = str(Path(genome).resolve())
+        output_path = str( Path('.').resolve() / Path(imagefile) )
+        commands = ['new', 'genome ' + genome_path, 'load ' + ','.join(input_paths), 'collapse', 'snapshot ' + output_path]
+        s.sendall(bytes('\n'.join(commands), 'ascii'))
+        s.close()
+        while not Path(output_path).is_file():
+            time.sleep(1)

--- a/rules/mapping/bowtie.rules
+++ b/rules/mapping/bowtie.rules
@@ -77,6 +77,7 @@ rule samtools_mpileup:
 rule igv_snapshot:
     message: "Create an alignment image for {wildcards.genome}-{wildcards.segment} with IGV"
     input:
+        igv_fp = str(Cfg['mapping']['igv_fp']),
         genome = GENOME,
         bams=expand(str(MAPPING_FP/"{{genome}}-{sample}.sorted.bam"), sample=Samples.keys()),
         bais=expand(str(MAPPING_FP/"{{genome}}-{sample}.sorted.bam.bai"), sample=Samples.keys())
@@ -85,19 +86,20 @@ rule igv_snapshot:
     output:
         png=str(MAPPING_FP/"{genome}-{segment}.alignment.png")
     run:
-        igv_render_script(input.genome, input.bams, output.png, params.segment)
+        igv_render(input.genome, input.bams, output.png, params.segment, input.igv_fp, "script")
 
 
 ### IGV Helper Functions
 
-
-def igv_render_script(genome, bams, imagefile, seqID=None):
+def igv_render(genome, bams, imagefile, seqID=None, igv_fp="igv", method="script"):
         """ Render an alignment to an image, given a genome and bam files.
 
         genome: path to a fasta file
         bams: list of path to a sorted, indexed bam file
         imagefile: path to the image to save
         seqID: (optional) sequence identifier to load from genome
+        igv_fp: (optional) path to IGV executable
+        method: (optional) method for controlling IGV process: "script" or "socket"
 
         The image file may be smaller than expected.  See
         igv_render_socket_nonblocking() for an attempt to enlarge the window
@@ -115,6 +117,16 @@ def igv_render_script(genome, bams, imagefile, seqID=None):
             'collapse',
             'snapshot ' + output_path,
             'exit']
+        if method == "script":
+            igvprefs = ["GENOME_LIST=;%s" % genome_path,
+                "DEFAULT_GENOME_KEY=%s" % genome_path]
+            _igv_control_script(igvcommands, igv_fp, igvprefs)
+        elif method == "socket":
+            _igv_control_socket(igvcommands, igv_fp)
+        else:
+            raise ValueError("method should be 'script' or 'socket', not '%s'" % method)
+
+def _igv_control_script(igvcommands, igv_fp, igvprefs):
         igvscript = tempfile.NamedTemporaryFile()
         igvscript.writelines(map(lambda x: bytes(x+'\n', 'ascii'), igvcommands))
         igvscript.flush()
@@ -126,23 +138,17 @@ def igv_render_script(genome, bams, imagefile, seqID=None):
         # I've also tried setting IGV.Bounds in an attempt to make the window
         # larger, but it doesn't seem to have any effect.
         igvprefsfile = tempfile.NamedTemporaryFile()
-        igvprefs = ["GENOME_LIST=;%s" % genome_path,
-            "DEFAULT_GENOME_KEY=%s" % genome_path]
         igvprefstext = map(lambda x: bytes(x+'\n', 'ascii'), igvprefs)
         igvprefsfile.writelines(igvprefstext)
         igvprefsfile.flush()
-        shell("xvfb-run -s '-screen 1 1920x1080x24' igv -o %s -b %s" % (igvprefsfile.name, igvscript.name))
+        shell("xvfb-run -s '-screen 1 1920x1080x24' %s -o %s -b %s" % (igv_fp, igvprefsfile.name, igvscript.name))
 
-def igv_render_socket_nonblocking(genome, bams, imagefile):
-        input_paths = [str(Path(bam).resolve()) for bam in bams]
-        genome_path = str(Path(genome).resolve())
-        output_path = str( Path('.').resolve() / Path(imagefile) )
-
+def _igv_control_socket(igvcommands, igv_fp):
         # Start up IGV.  Use a port between 10000 and the max available, based
         # on the PID of this process.  (TODO is using this pid safe?)
         port = 10000 + os.getpid()%(2**16-10000)
         xauth = "/tmp/xauth-%d" % os.getpid()
-        igv = subprocess.Popen(["xvfb-run", "-l", "-f" , xauth, "-s", "-screen 1 1920x1080x24", "igv", "-p", str(port)])
+        igv = subprocess.Popen(["xvfb-run", "-l", "-f" , xauth, "-s", "-screen 1 1920x1080x24", str(igv_fp), "-p", str(port)])
 
         # Connect to running IGV
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -160,21 +166,6 @@ def igv_render_socket_nonblocking(genome, bams, imagefile):
         shell("DISPLAY="+display+" XAUTHORITY="+xauth+" xdotool search --onlyvisible --name IGV windowsize --sync 100% 100%")
 
         # Generate screenshot
-        commands = ['new', 'genome ' + genome_path, 'load ' + ','.join(input_paths), 'collapse', 'snapshot ' + output_path, 'exit']
-        s.sendall(bytes('\n'.join(commands), 'ascii'))
+        s.sendall(bytes('\n'.join(igvcommands), 'ascii'))
         s.close()
         igv.wait()
-
-# NOTE: this version assumes an already-running IGV configured to allow access
-# on the default port (60151), so it's not as useful for automation.
-def igv_render_socket(genome, bams, imagefile):
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        s.connect(('localhost', 60151))
-        input_paths = [str(Path(bam).resolve()) for bam in bams]
-        genome_path = str(Path(genome).resolve())
-        output_path = str( Path('.').resolve() / Path(imagefile) )
-        commands = ['new', 'genome ' + genome_path, 'load ' + ','.join(input_paths), 'collapse', 'snapshot ' + output_path]
-        s.sendall(bytes('\n'.join(commands), 'ascii'))
-        s.close()
-        while not Path(output_path).is_file():
-            time.sleep(1)

--- a/rules/targets/targets.rules
+++ b/rules/targets/targets.rules
@@ -34,6 +34,15 @@ TARGET_ASSEMBLY = (
 TARGET_PAIR = expand(str(ASSEMBLY_FP/'paired'/'{sample}.assembled.fastq'), sample=Samples.keys())
 
 ####################
+## mapping
+####################
+
+TARGET_MAPPING = [
+        expand(str(MAPPING_FP/"{genome}-{sample}.sorted.bam.bai"), genome=GenomeSegments.keys(), sample=Samples.keys()),
+        expand(str(MAPPING_FP/"{genome}-{sample}.raw.bcf"), genome=GenomeSegments.keys(), sample=Samples.keys()),
+        [expand(str(MAPPING_FP/"{genome}-{segment}.alignment.png"), genome=g, segment=GenomeSegments[g]) for g in GenomeSegments.keys()]]
+
+####################
 ## annotation
 ####################
 
@@ -45,4 +54,4 @@ TARGET_ANNOTATE = expand(str(ANNOTATION_FP/'summary'/'{sample}.tsv'), sample=Sam
 ####################
 TARGET_REPORT = [str(QC_FP/'preprocess_summary.tsv'), str(QC_FP/'fastqc_quality.tsv')]
 
-TARGET_ALL = TARGET_QC + TARGET_DECONTAM + TARGET_CLASSIFY + TARGET_ASSEMBLY + TARGET_ANNOTATE + TARGET_REPORT
+TARGET_ALL = TARGET_QC + TARGET_DECONTAM + TARGET_CLASSIFY + TARGET_ASSEMBLY + TARGET_ANNOTATE + TARGET_REPORT + TARGET_MAPPING

--- a/sunbeamlib/__init__.py
+++ b/sunbeamlib/__init__.py
@@ -4,6 +4,7 @@ __license__ = "GPL2+"
 from snakemake.utils import listfiles
 from snakemake.workflow import expand
 import os
+import re
 
 
 def build_sample_list(data_fp, filename_fmt, excluded):
@@ -90,3 +91,13 @@ def circular(seq, kmin, kmax, min_len):
             return True
     return False
 
+def read_seq_ids(fasta_fp):
+    """
+    Return the sequence identifiers for a given fasta filename.
+    """
+    ids = []
+    with open(str(fasta_fp)) as f:
+        for line in f:
+            if line.startswith('>'):
+                ids.append(re.split('[> ]', line)[1])
+    return ids

--- a/sunbeamlib/__init__.py
+++ b/sunbeamlib/__init__.py
@@ -5,6 +5,7 @@ from snakemake.utils import listfiles
 from snakemake.workflow import expand
 import os
 import re
+from Bio import SeqIO
 
 
 def build_sample_list(data_fp, filename_fmt, excluded):
@@ -95,9 +96,4 @@ def read_seq_ids(fasta_fp):
     """
     Return the sequence identifiers for a given fasta filename.
     """
-    ids = []
-    with open(str(fasta_fp)) as f:
-        for line in f:
-            if line.startswith('>'):
-                ids.append(re.split('[> ]', line)[1])
-    return ids
+    return [record.id for record in SeqIO.parse(str(fasta_fp), "fasta")]

--- a/sunbeamlib/data/default_config.yml
+++ b/sunbeamlib/data/default_config.yml
@@ -96,3 +96,4 @@ blastdbs:
 mapping:
   suffix: mapping
   genomes_fp: ""
+  igv_fp: ""

--- a/sunbeamlib/igv.py
+++ b/sunbeamlib/igv.py
@@ -1,0 +1,95 @@
+"""
+Helper functions for interfacing with the Integrative Genomics Viewer (IGV).
+
+Dependencies:
+ * IGV
+ * xvfb
+ * xdotool (for the socket-based method)
+"""
+
+from pathlib import Path
+from snakemake import shell
+import socket
+import subprocess
+import tempfile
+import time
+import os
+
+def render(genome, bams, imagefile, seqID=None, igv_fp="igv", method="script"):
+        """ Render an alignment to an image, given a genome and bam files.
+
+        genome: path to a fasta file
+        bams: list of path to a sorted, indexed bam file
+        imagefile: path to the image to save
+        seqID: (optional) sequence identifier to load from genome
+        igv_fp: (optional) path to IGV executable
+        method: (optional) method for controlling IGV process: "script" or "socket"
+
+        The image file may be smaller than expected.  See
+        igv_render_socket_nonblocking() for an attempt to enlarge the window
+        before saving the image.
+        """
+        input_paths = [str(Path(bam).resolve()) for bam in bams]
+        genome_path = str(Path(genome).resolve())
+        output_path = str( Path('.').resolve() / Path(imagefile) )
+        genome_cmd = 'genome ' + genome_path
+        if seqID:
+            genome_cmd += "\ngoto %s" % seqID
+        igvcommands = ['new',
+            genome_cmd,
+            'load ' + ','.join(input_paths),
+            'collapse',
+            'snapshot ' + output_path,
+            'exit']
+        if method == "script":
+            igvprefs = ["GENOME_LIST=;%s" % genome_path,
+                "DEFAULT_GENOME_KEY=%s" % genome_path]
+            _control_script(igvcommands, igv_fp, igvprefs)
+        elif method == "socket":
+            _control_socket(igvcommands, igv_fp)
+        else:
+            raise ValueError("method should be 'script' or 'socket', not '%s'" % method)
+
+def _control_script(igvcommands, igv_fp, igvprefs):
+        igvscript = tempfile.NamedTemporaryFile()
+        igvscript.writelines(map(lambda x: bytes(x+'\n', 'ascii'), igvcommands))
+        igvscript.flush()
+        # If previous genome files listed in IGV's preferences are no longer
+        # available, IGV will throw a null pointer exception at startup and
+        # batch commands will fail.  So, we'll use a preferences override file
+        # to list the genome file used here.  (This is probably an IGV bug.  We
+        # should see if it happens in the latest release.)
+        # I've also tried setting IGV.Bounds in an attempt to make the window
+        # larger, but it doesn't seem to have any effect.
+        igvprefsfile = tempfile.NamedTemporaryFile()
+        igvprefstext = map(lambda x: bytes(x+'\n', 'ascii'), igvprefs)
+        igvprefsfile.writelines(igvprefstext)
+        igvprefsfile.flush()
+        shell("xvfb-run -s '-screen 1 1920x1080x24' %s -o %s -b %s" % (igv_fp, igvprefsfile.name, igvscript.name))
+
+def _control_socket(igvcommands, igv_fp):
+        # Start up IGV.  Use a port between 10000 and the max available, based
+        # on the PID of this process.  (TODO is using this pid safe?)
+        port = 10000 + os.getpid()%(2**16-10000)
+        xauth = "/tmp/xauth-%d" % os.getpid()
+        igvproc = subprocess.Popen(["xvfb-run", "-l", "-f" , xauth, "-s", "-screen 1 1920x1080x24", str(igv_fp), "-p", str(port)])
+
+        # Connect to running IGV
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        while True:
+            try:
+                s.connect(('localhost', port))
+                break
+            except ConnectionRefusedError:
+                time.sleep(0.5)
+
+        # Based on http://unix.stackexchange.com/questions/5999/ :
+        # This should make the window as large as the virtual X display, but in
+        # practice my screenshots aren't going over 1280 x 1296.
+        display = ":99"
+        shell("DISPLAY="+display+" XAUTHORITY="+xauth+" xdotool search --onlyvisible --name IGV windowsize --sync 100% 100%")
+
+        # Generate screenshot
+        s.sendall(bytes('\n'.join(igvcommands), 'ascii'))
+        s.close()
+        igvproc.wait()

--- a/tests/prep_config_file.py
+++ b/tests/prep_config_file.py
@@ -20,6 +20,7 @@ def main():
     config['blastdbs']['root_fp'] = "local/blast"
     config['blastdbs']['nucleotide']['bacteria'] = 'bacteria.fa'
     config['mapping']['genomes_fp'] = "indexes"
+    config['mapping']['igv_fp'] = "local/IGV/igv.sh"
 
     sys.stdout.write(yaml.dump(config))
 

--- a/tests/prep_config_file.py
+++ b/tests/prep_config_file.py
@@ -19,6 +19,7 @@ def main():
     config['assembly']['cap3_fp'] = "local/CAP3"
     config['blastdbs']['root_fp'] = "local/blast"
     config['blastdbs']['nucleotide']['bacteria'] = 'bacteria.fa'
+    config['mapping']['genomes_fp'] = "indexes"
 
     sys.stdout.write(yaml.dump(config))
 

--- a/tests/targets.txt
+++ b/tests/targets.txt
@@ -21,3 +21,6 @@ qc/paired/dummybfragilis_R1.fastq.gz
 qc/paired/dummybfragilis_R2.fastq.gz
 qc/paired/dummyecoli_R1.fastq.gz
 qc/paired/dummyecoli_R2.fastq.gz
+
+mapping/human-KI270762.1.alignment.png
+mapping/phix174-gi|9626372|ref|NC_001422.1|.alignment.png

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -4,8 +4,6 @@ set -e # Stop on errors
 
 # Ensure we can activate the environment
 export PATH=$PATH:$HOME/miniconda3/bin
-# Use local copy of IGV if present
-[ -d $HOME/IGV ] && export PATH=$PATH:$HOME/IGV
 
 # Set up paths
 ROOT=`pwd`

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -4,6 +4,8 @@ set -e # Stop on errors
 
 # Ensure we can activate the environment
 export PATH=$PATH:$HOME/miniconda3/bin
+# Use local copy of IGV if present
+[ -d $HOME/IGV ] && export PATH=$PATH:$HOME/IGV
 
 # Set up paths
 ROOT=`pwd`


### PR DESCRIPTION
This adds new rules for aligning all samples present to each sequence in each genome file present, using bowtie2/samtools for the alignments and IGV for a graphical representation of each alignment.  The tests are updated to check for the right image files, but no new data files have been added.  The test setup also does a basic install of IGV into `sunbeam/local`, with a configuration option for the path to the IGV executable.

Some things to note:

 * I added a new helper function to `sunbeamlib/__init__.py` that reads out sequence identifiers from a given fasta file.  There are IGV-related functions still in bowtie.rules.
 * To match the paths used by the existing index_files function, I rewrote my original rules to put the bowtie2 index files inside the indexes directory itself rather than in the mapping suffix directory.  Let me know if that should be done differently, though.
 * I think Erik had mentioned keeping out TARGET_MAPPING from TARGET_ALL for now, but I wanted the test to trigger the mapping rules so I have it in there right now.
 * This does a quick-n-dirty IGV installation so the tests can run, but there's probably a better way to handle that during the environment setup.  Right now it's a separate step in the Travis configuration.
 * The latest IGV doesn't work right with this.  The alignment images are blank even with real input data.  Right now it installs a version that I know works on our systems.
 * Since no new genomes or raw files are added, the images don't really show anything during testing, though the tests do succeed.
 * The alignment image filenames can be very ugly depending on the sequence IDs in the genome files.  (`phix174-gi|9626372|ref|NC_001422.1|.alignment.png` is technically a valid filename, but, well...)
