### PR TITLE
Add IGV preferences support for mapping rules

### DIFF
--- a/rules/mapping/bowtie.rules
+++ b/rules/mapping/bowtie.rules
@@ -28,22 +28,25 @@ rule bowtie2_align:
         rp = expand(str(Cfg['all']['data_fp'] / Cfg['all']['filename_fmt']), rp = ['R1','R2'], sample="{sample}"),
         indices = INDICES
     output: temp(str(MAPPING_FP/"{genome}-{sample}.sam"))
+    threads: Cfg['mapping']['threads']
     params:
         genome="{genome}",
         index_fp=str(Cfg['mapping']['genomes_fp'])
-    shell: "bowtie2 -x {params.index_fp}/{params.genome} -1 {input.rp[0]} -2 {input.rp[1]} -S {output}"
+    shell: "bowtie2 --threads {threads} -x {params.index_fp}/{params.genome} -1 {input.rp[0]} -2 {input.rp[1]} -S {output}"
 
 rule samtools_view:
     message: "Converting {wildcards.genome}-{wildcards.sample} alignment from SAM to BAM format with samtools"
     input: str(MAPPING_FP/"{genome}-{sample}.sam")
     output: str(MAPPING_FP/"{genome}-{sample}.bam")
-    shell: "samtools view -bS {input} > {output}"
+    threads: Cfg['mapping']['threads']
+    shell: "samtools view -@ {threads} -bS {input} > {output}"
 
 rule samtools_sort:
     message: "Sorting {input} with samtools"
     input: str(MAPPING_FP/"{genome}-{sample}.bam")
     output: str(MAPPING_FP/"{genome}-{sample}.sorted.bam")
-    shell: "samtools sort {input} > {output}"
+    threads: Cfg['mapping']['threads']
+    shell: "samtools sort -@ {threads} {input} > {output}"
 
 rule samtools_index:
     message: "Indexing {input} with samtools"

--- a/rules/mapping/bowtie.rules
+++ b/rules/mapping/bowtie.rules
@@ -69,8 +69,10 @@ rule igv_snapshot:
         bams=expand(str(MAPPING_FP/"{{genome}}-{sample}.sorted.bam"), sample=Samples.keys()),
         bais=expand(str(MAPPING_FP/"{{genome}}-{sample}.sorted.bam.bai"), sample=Samples.keys())
     params:
-        segment="{segment}"
+        segment="{segment}",
+        igv_prefs=Cfg['mapping']['igv_prefs']
     output:
         png=str(MAPPING_FP/"{genome}-{segment}.alignment.png")
     run:
-        igv.render(input.genome, input.bams, output.png, params.segment, input.igv_fp, "script")
+        igv.render(input.genome, sorted(input.bams), output.png, params.segment,
+                   input.igv_fp, "script", params.igv_prefs)

--- a/sunbeamlib/data/default_config.yml
+++ b/sunbeamlib/data/default_config.yml
@@ -97,3 +97,13 @@ mapping:
   suffix: mapping
   genomes_fp: ""
   igv_fp: ""
+  igv_prefs:
+    # Smooth rendered text.  By default it looks jagged.
+    ENABLE_ANTIALIASING: true
+    # The pixel width of the left panel that shows the name of the input files.
+    # The default is a bit too narrow and will truncate long filenames.
+    NAME_PANEL_WIDTH: 360
+    # The alignment window size, in kb, below which alignments will become
+    # visible.  We don't want to ever require zooming so we will set it to a
+    # high value.
+    SAM.MAX_VISIBLE_RANGE: 1000

--- a/sunbeamlib/data/default_config.yml
+++ b/sunbeamlib/data/default_config.yml
@@ -97,6 +97,7 @@ mapping:
   suffix: mapping
   genomes_fp: ""
   igv_fp: ""
+  threads: 4
   igv_prefs:
     # Smooth rendered text.  By default it looks jagged.
     ENABLE_ANTIALIASING: true

--- a/sunbeamlib/igv.py
+++ b/sunbeamlib/igv.py
@@ -15,7 +15,7 @@ import tempfile
 import time
 import os
 
-def render(genome, bams, imagefile, seqID=None, igv_fp="igv", method="script"):
+def render(genome, bams, imagefile, seqID=None, igv_fp="igv", method="script", igv_prefs={}):
         """ Render an alignment to an image, given a genome and bam files.
 
         genome: path to a fasta file
@@ -24,6 +24,7 @@ def render(genome, bams, imagefile, seqID=None, igv_fp="igv", method="script"):
         seqID: (optional) sequence identifier to load from genome
         igv_fp: (optional) path to IGV executable
         method: (optional) method for controlling IGV process: "script" or "socket"
+        igv_prefs: (optional) dictionary of IGV preferences to override
 
         The image file may be smaller than expected.  See
         igv_render_socket_nonblocking() for an attempt to enlarge the window
@@ -42,37 +43,38 @@ def render(genome, bams, imagefile, seqID=None, igv_fp="igv", method="script"):
             'snapshot ' + output_path,
             'exit']
         if method == "script":
-            igvprefs = ["GENOME_LIST=;%s" % genome_path,
-                "DEFAULT_GENOME_KEY=%s" % genome_path]
-            _control_script(igvcommands, igv_fp, igvprefs)
+            # If previous genome files listed in IGV's preferences are no
+            # longer available, IGV will throw a null pointer exception at
+            # startup and batch commands will fail.  So, we'll use a
+            # preferences override file to list the genome file used here.
+            # (This is probably an IGV bug.  We should see if it happens in the
+            # latest release.) I've also tried setting IGV.Bounds in an attempt
+            # to make the window larger, but it doesn't seem to have any
+            # effect.
+            igv_prefs["GENOME_LIST"] = ";" + genome_path
+            igv_prefs["DEFAULT_GENOME_KEY"] = genome_path
+            _control_script(igvcommands, igv_fp, igv_prefs)
         elif method == "socket":
-            _control_socket(igvcommands, igv_fp)
+            _control_socket(igvcommands, igv_fp, igv_prefs)
         else:
             raise ValueError("method should be 'script' or 'socket', not '%s'" % method)
 
-def _control_script(igvcommands, igv_fp, igvprefs):
+def _control_script(igvcommands, igv_fp, igv_prefs):
         igvscript = tempfile.NamedTemporaryFile()
         igvscript.writelines(map(lambda x: bytes(x+'\n', 'ascii'), igvcommands))
         igvscript.flush()
-        # If previous genome files listed in IGV's preferences are no longer
-        # available, IGV will throw a null pointer exception at startup and
-        # batch commands will fail.  So, we'll use a preferences override file
-        # to list the genome file used here.  (This is probably an IGV bug.  We
-        # should see if it happens in the latest release.)
-        # I've also tried setting IGV.Bounds in an attempt to make the window
-        # larger, but it doesn't seem to have any effect.
-        igvprefsfile = tempfile.NamedTemporaryFile()
-        igvprefstext = map(lambda x: bytes(x+'\n', 'ascii'), igvprefs)
-        igvprefsfile.writelines(igvprefstext)
-        igvprefsfile.flush()
+        igvprefsfile = _write_prefs(igv_prefs)
         shell("xvfb-run -s '-screen 1 1920x1080x24' %s -o %s -b %s" % (igv_fp, igvprefsfile.name, igvscript.name))
 
-def _control_socket(igvcommands, igv_fp):
+def _control_socket(igvcommands, igv_fp, igv_prefs):
+        igvprefsfile = _write_prefs(igv_prefs)
         # Start up IGV.  Use a port between 10000 and the max available, based
         # on the PID of this process.  (TODO is using this pid safe?)
         port = 10000 + os.getpid()%(2**16-10000)
         xauth = "/tmp/xauth-%d" % os.getpid()
-        igvproc = subprocess.Popen(["xvfb-run", "-l", "-f" , xauth, "-s", "-screen 1 1920x1080x24", str(igv_fp), "-p", str(port)])
+        xvfb_cmdline = ["xvfb-run", "-l", "-f" , xauth, "-s", "-screen 1 1920x1080x24"]
+        igv_cmdline = [ str(igv_fp), "-p", str(port), "-o", igvprefsfile.name ]
+        igvproc = subprocess.Popen(xvfb_cmdline + igv_cmdline)
 
         # Connect to running IGV
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -93,3 +95,10 @@ def _control_socket(igvcommands, igv_fp):
         s.sendall(bytes('\n'.join(igvcommands), 'ascii'))
         s.close()
         igvproc.wait()
+
+def _write_prefs(igv_prefs):
+        igvprefsfile = tempfile.NamedTemporaryFile()
+        for k,v in igv_prefs.items():
+            igvprefsfile.write(bytes("%s=%s\n" % (k, v), 'ascii'))
+        igvprefsfile.flush()
+        return igvprefsfile

--- a/sunbeamlib/igv.py
+++ b/sunbeamlib/igv.py
@@ -15,7 +15,7 @@ import tempfile
 import time
 import os
 
-def render(genome, bams, imagefile, seqID=None, igv_fp="igv", method="script", igv_prefs={}):
+def render(genome, bams, imagefile, seqID=None, igv_fp="igv", method="script", igv_prefs=None):
         """ Render an alignment to an image, given a genome and bam files.
 
         genome: path to a fasta file
@@ -30,6 +30,7 @@ def render(genome, bams, imagefile, seqID=None, igv_fp="igv", method="script", i
         igv_render_socket_nonblocking() for an attempt to enlarge the window
         before saving the image.
         """
+        igv_prefs = igv_prefs or {}
         input_paths = [str(Path(bam).resolve()) for bam in bams]
         genome_path = str(Path(genome).resolve())
         output_path = str( Path('.').resolve() / Path(imagefile) )


### PR DESCRIPTION
This fixes #59 by adding support for specifying IGV options via the sunbeam configuration file.  A dictionary of name/value pairs called igv_prefs in the mapping section is used to populate an IGV preferences override file.  The BAM filenames are also sorted when given to igv.render() in the mapping rules so that the alignment image stacks will be organized and ordered in a predictable way.