### PR TITLE
Add coverage statistics for mapping rules

### DIFF
--- a/rules/mapping/bowtie.rules
+++ b/rules/mapping/bowtie.rules
@@ -1,6 +1,8 @@
 # -*- mode: Snakemake -*-
 
 from sunbeamlib import index_files, igv
+import subprocess
+import numpy
 
 # Generate Snakemake template strings for a few commonly-used parameters below
 INDICES = index_files('{genome}', Cfg['mapping']['genomes_fp'])
@@ -47,6 +49,50 @@ rule samtools_sort:
     output: str(MAPPING_FP/"{genome}-{sample}.sorted.bam")
     threads: Cfg['mapping']['threads']
     shell: "samtools sort -@ {threads} {input} > {output}"
+
+def get_coverage_stats(genome_name, bamfiles, sample_names, output_fp):
+    """Produce a CSV table of alignment stats for a single genome.
+    
+    genome_name: identifier for genome
+    bamfiles: list of file paths to BAM files
+    sample_names: list of idenifiers for the sample for each BAM file
+    output_fp: path to CSV output file
+    """
+    output_rows = []
+    for bamfile, sample in sorted(zip(bamfiles, sample_names)):
+        # Get coverage depth at each position, even if zero across whole segment
+        p = subprocess.Popen(["samtools", "depth", "-aa", bamfile], stdout=subprocess.PIPE)
+        stdout, stderr = p.communicate()
+        # Organize into a list of depths for each segment
+        lines = str(stdout, 'ascii').splitlines()
+        reader = csv.reader(lines, delimiter='\t')
+        data = {}
+        for row in reader:
+            if not data.get(row[0]):
+                data[row[0]] = []
+            data[row[0]].append(int(row[2]))
+        # Summarize stats for all segments present and append to output
+        for segment in data.keys():
+            minval = numpy.min(data[segment])
+            maxval = numpy.max(data[segment])
+            mean   = numpy.mean(data[segment])
+            median = numpy.median(data[segment])
+            stddev = numpy.std(data[segment])
+            row = [genome_name, segment, sample, minval, maxval, mean, median, stddev]
+            output_rows.append(row)
+    # write out stats per segment per sample
+    fields = ['Genome', 'Segment', 'Sample', 'Min', 'Max', 'Mean', 'Median', 'Std Dev']
+    with open(output_fp, 'w') as f:
+        writer = csv.writer(f)
+        writer.writerow(fields)
+        writer.writerows(output_rows)
+
+rule samtools_get_coverage:
+    message: "Tabulating coverage stats for {wildcards.genome}"
+    input: expand(str(MAPPING_FP/"{{genome}}-{sample}.sorted.bam"), sample=Samples.keys())
+    output: str(MAPPING_FP/"{genome}.coverage.csv")
+    run:
+        get_coverage_stats(wildcards.genome, input, Samples.keys(), output[0])
 
 rule samtools_index:
     message: "Indexing {input} with samtools"

--- a/rules/mapping/bowtie.rules
+++ b/rules/mapping/bowtie.rules
@@ -1,8 +1,6 @@
 # -*- mode: Snakemake -*-
 
-from sunbeamlib import index_files, igv
-import subprocess
-import numpy
+from sunbeamlib import index_files, igv, samtools
 
 # Generate Snakemake template strings for a few commonly-used parameters below
 INDICES = index_files('{genome}', Cfg['mapping']['genomes_fp'])
@@ -50,51 +48,12 @@ rule samtools_sort:
     threads: Cfg['mapping']['threads']
     shell: "samtools sort -@ {threads} {input} > {output}"
 
-def get_coverage_stats(genome_name, bamfiles, sample_names, output_fp):
-    """Produce a CSV table of alignment stats for a single genome.
-    
-    genome_name: identifier for genome
-    bamfiles: list of file paths to BAM files
-    sample_names: list of idenifiers for the sample for each BAM file
-    output_fp: path to CSV output file
-    """
-    output_rows = []
-    for bamfile, sample in sorted(zip(bamfiles, sample_names)):
-        # Get coverage depth at each position, even if zero across whole segment
-        p = subprocess.Popen(["samtools", "depth", "-aa", bamfile], stdout=subprocess.PIPE)
-        stdout, stderr = p.communicate()
-        # Organize into a list of depths for each segment
-        lines = str(stdout, 'ascii').splitlines()
-        reader = csv.reader(lines, delimiter='\t')
-        data = {}
-        for row in reader:
-            if not data.get(row[0]):
-                data[row[0]] = []
-            data[row[0]].append(int(row[2]))
-        # Summarize stats for all segments present and append to output
-        for segment in data.keys():
-            minval     = numpy.min(data[segment])
-            maxval     = numpy.max(data[segment])
-            mean       = numpy.mean(data[segment])
-            median     = numpy.median(data[segment])
-            stddev     = numpy.std(data[segment])
-            gen_cov    = len(list(filter(lambda x: x!=0, data[segment])))
-            gen_length = len(data[segment])
-            row = [genome_name, segment, sample, minval, maxval, mean, median, stddev, gen_cov, gen_length]
-            output_rows.append(row)
-    # write out stats per segment per sample
-    fields = ['Genome', 'Segment', 'Sample', 'Min', 'Max', 'Mean', 'Median', 'Std Dev', 'Segment Coverage', 'Segment Length']
-    with open(output_fp, 'w') as f:
-        writer = csv.writer(f)
-        writer.writerow(fields)
-        writer.writerows(output_rows)
-
 rule samtools_get_coverage:
     message: "Tabulating coverage stats for {wildcards.genome}"
     input: expand(str(MAPPING_FP/"{{genome}}-{sample}.sorted.bam"), sample=Samples.keys())
     output: str(MAPPING_FP/"{genome}.coverage.csv")
     run:
-        get_coverage_stats(wildcards.genome, input, Samples.keys(), output[0])
+        samtools.get_coverage_stats(wildcards.genome, input, Samples.keys(), output[0])
 
 rule samtools_index:
     message: "Indexing {input} with samtools"

--- a/rules/mapping/bowtie.rules
+++ b/rules/mapping/bowtie.rules
@@ -73,15 +73,17 @@ def get_coverage_stats(genome_name, bamfiles, sample_names, output_fp):
             data[row[0]].append(int(row[2]))
         # Summarize stats for all segments present and append to output
         for segment in data.keys():
-            minval = numpy.min(data[segment])
-            maxval = numpy.max(data[segment])
-            mean   = numpy.mean(data[segment])
-            median = numpy.median(data[segment])
-            stddev = numpy.std(data[segment])
-            row = [genome_name, segment, sample, minval, maxval, mean, median, stddev]
+            minval     = numpy.min(data[segment])
+            maxval     = numpy.max(data[segment])
+            mean       = numpy.mean(data[segment])
+            median     = numpy.median(data[segment])
+            stddev     = numpy.std(data[segment])
+            gen_cov    = len(list(filter(lambda x: x!=0, data[segment])))
+            gen_length = len(data[segment])
+            row = [genome_name, segment, sample, minval, maxval, mean, median, stddev, gen_cov, gen_length]
             output_rows.append(row)
     # write out stats per segment per sample
-    fields = ['Genome', 'Segment', 'Sample', 'Min', 'Max', 'Mean', 'Median', 'Std Dev']
+    fields = ['Genome', 'Segment', 'Sample', 'Min', 'Max', 'Mean', 'Median', 'Std Dev', 'Segment Coverage', 'Segment Length']
     with open(output_fp, 'w') as f:
         writer = csv.writer(f)
         writer.writerow(fields)

--- a/rules/targets/targets.rules
+++ b/rules/targets/targets.rules
@@ -40,6 +40,7 @@ TARGET_PAIR = expand(str(ASSEMBLY_FP/'paired'/'{sample}.assembled.fastq'), sampl
 TARGET_MAPPING = [
         expand(str(MAPPING_FP/"{genome}-{sample}.sorted.bam.bai"), genome=GenomeSegments.keys(), sample=Samples.keys()),
         expand(str(MAPPING_FP/"{genome}-{sample}.raw.bcf"), genome=GenomeSegments.keys(), sample=Samples.keys()),
+        expand(str(MAPPING_FP/"{genome}.coverage.csv"), genome=GenomeSegments.keys()),
         [expand(str(MAPPING_FP/"{genome}-{segment}.alignment.png"), genome=g, segment=GenomeSegments[g]) for g in GenomeSegments.keys()]]
 
 ####################

--- a/sunbeamlib/samtools.py
+++ b/sunbeamlib/samtools.py
@@ -1,0 +1,48 @@
+""" Helper functions for working with samtools. """
+
+import subprocess
+import numpy
+import csv
+
+def get_coverage_stats(genome_name, bamfiles, sample_names, output_fp):
+    """Produce a CSV table of alignment stats for a single genome.
+    
+    genome_name: identifier for genome
+    bamfiles: list of file paths to BAM files
+    sample_names: list of idenifiers for the sample for each BAM file
+    output_fp: path to CSV output file
+
+    There's lot of redundant information (genome name on every row, segment
+    name and stats across all relevant rows) but it makes the results a bit
+    easier to work with.
+    """
+    output_rows = []
+    for bamfile, sample in sorted(zip(bamfiles, sample_names)):
+        # Get coverage depth at each position, even if zero across whole segment
+        p = subprocess.Popen(["samtools", "depth", "-aa", bamfile], stdout=subprocess.PIPE)
+        stdout, stderr = p.communicate()
+        # Organize into a list of depths for each segment
+        lines = str(stdout, 'ascii').splitlines()
+        reader = csv.reader(lines, delimiter='\t')
+        data = {}
+        for row in reader:
+            if not data.get(row[0]):
+                data[row[0]] = []
+            data[row[0]].append(int(row[2]))
+        # Summarize stats for all segments present and append to output
+        for segment in data.keys():
+            minval     = numpy.min(data[segment])
+            maxval     = numpy.max(data[segment])
+            mean       = numpy.mean(data[segment])
+            median     = numpy.median(data[segment])
+            stddev     = numpy.std(data[segment])
+            gen_cov    = len(list(filter(lambda x: x!=0, data[segment])))
+            gen_length = len(data[segment])
+            row = [genome_name, segment, sample, minval, maxval, mean, median, stddev, gen_cov, gen_length]
+            output_rows.append(row)
+    # write out stats per segment per sample
+    fields = ['Genome', 'Segment', 'Sample', 'Min', 'Max', 'Mean', 'Median', 'Std Dev', 'Segment Coverage', 'Segment Length']
+    with open(output_fp, 'w') as f:
+        writer = csv.writer(f)
+        writer.writerow(fields)
+        writer.writerows(output_rows)

--- a/tests/targets.txt
+++ b/tests/targets.txt
@@ -24,3 +24,5 @@ qc/paired/dummyecoli_R2.fastq.gz
 
 mapping/human-KI270762.1.alignment.png
 mapping/phix174-gi|9626372|ref|NC_001422.1|.alignment.png
+mapping/human.coverage.csv
+mapping/phix174.coverage.csv


### PR DESCRIPTION
This adds a rule to the mapping section for creating some coverage statistics per genome across samples.

It outputs a table in CSV format for each target that summarizes per genome/segment/sample combination:

 * min/max/mean/stddev of depth
 * coverage of genome segment in number of bases
 * length of genome segment in number of bases