### PR TITLE
Fix #74: specify snakemake=3.13.0 in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-snakemake
+snakemake=3.13.0
 biopython
 trimmomatic
 fastqc


### PR DESCRIPTION
When run under the latest Snakemake available from the bioconda Anaconda channel, multiple rules fail because some of the Snakemake objects have changed. Version 3.13.2 fails, but 3.13.0 still works.  This sets our requirement for Snakemake to version 3.13.0 explicitly.