### PR TITLE
Fix #39: Bypass cap3 for empty contigs in assembly rules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 before_install:
+  - sudo apt-get -qq update
   - sudo apt-get install xdotool
 install:
   - bash install.sh sunbeam anaconda_log.txt

--- a/rules/assembly/assembly.rules
+++ b/rules/assembly/assembly.rules
@@ -46,8 +46,10 @@ rule cap3:
         str(ASSEMBLY_FP/'log'/'cap3'/'{sample}.out')
     shell:
         """
+        [[ -s {input.contig} ]] && \
         {input.cap3} {input.contig} &> {log} && \
-        cat {input.contig}.cap.singlets {input.contig}.cap.contigs > {output}
+        cat {input.contig}.cap.singlets {input.contig}.cap.contigs > {output} || \
+        cp {input.contig} {output} &> {log}
         """
 
 rule save_intermediates:

--- a/sunbeamlib/igv.py
+++ b/sunbeamlib/igv.py
@@ -32,7 +32,9 @@ def render(genome, bams, imagefile, seqID=None, igv_fp="igv", method="script", i
         before saving the image.
         """
         igv_prefs = igv_prefs or {}
-        input_paths = [str(Path(bam).resolve()) for bam in bams]
+        genome = str(genome)
+        imagefile = str(imagefile)
+        input_paths = [str(Path(str(bam)).resolve()) for bam in bams]
         genome_path = str(Path(genome).resolve())
         output_path = str( Path('.').resolve() / Path(imagefile) )
         # build a "seqID:1:length" string to force IGV to display the full

--- a/tests/generate_dummy_data.py
+++ b/tests/generate_dummy_data.py
@@ -5,6 +5,10 @@
 
 import sys
 import os
+import random
+# So that "random" values in this testing will actually be arbitrary but still
+# deterministic:
+random.seed(sum(bytes('sunbeam', 'ascii')))
 
 def reverse_complement(dna):
 	dnadict = {'A':'T','C':'G','G':'C','T':'A'}
@@ -48,6 +52,21 @@ def write_fastq(genome_segment, locs, sample_name,file_fp):
 		file2.write("%s\n" % ''.join("G"*250))
 	file2.close()
 
+# Using this to trigger a failure to assemble any contigs in the assembly
+# rules.  Note the random.seed() call above so that we will always get the same
+# sequences.
+def write_random_fastq(sample_name, file_fp, numreads=4, readlen=100):
+    """Write a pair of sample fastq files containing randomized sequences."""
+    dna = 'ATCG'
+    randread = lambda: ''.join([dna[random.randint(0,len(dna)-1)] for i in range(readlen)])
+    for r in (1,2):
+        with open(file_fp + '/PCMP_'+sample_name+'_R%s.fastq' % r, 'w') as f:
+            for s in range(numreads):
+                f.write('@read%s\n' % s)
+                f.write('%s\n' % randread())
+                f.write('+\n')
+                f.write('%s\n' % ('G'*readlen))
+
 def generate_dummyfastq(rootpath):
 
 	raw_fp = rootpath + "/raw"
@@ -73,6 +92,7 @@ def generate_dummyfastq(rootpath):
 
 	write_fastq(genome_segment_e, locs, "dummyecoli", fastq_fp)
 	write_fastq(genome_segment_b, locs, "dummybfragilis",fastq_fp)
+	write_random_fastq('random', fastq_fp)
 
 
 if __name__ == '__main__':

--- a/tests/targets.txt
+++ b/tests/targets.txt
@@ -1,26 +1,34 @@
 annotation/blastn/bacteria/contig/dummybfragilis.xml
 annotation/blastn/bacteria/contig/dummyecoli.xml
+annotation/blastn/bacteria/contig/random.xml
 
 annotation/summary/dummybfragilis.tsv
 annotation/summary/dummyecoli.tsv
+annotation/summary/random.tsv
 
 assembly/dummybfragilis_assembly/final-contigs.fa
 assembly/dummyecoli_assembly/final-contigs.fa
+assembly/random_assembly/final-contigs.fa
 
 classify/kraken/all_samples.biom
 classify/kraken/all_samples.tsv
 classify/kraken/dummybfragilis-taxa.tsv
 classify/kraken/dummyecoli-taxa.tsv
+classify/kraken/random-taxa.tsv
 
 qc/decontam/dummybfragilis_R1.fastq
 qc/decontam/dummybfragilis_R2.fastq
 qc/decontam/dummyecoli_R1.fastq
 qc/decontam/dummyecoli_R2.fastq
+qc/decontam/random_R1.fastq
+qc/decontam/random_R2.fastq
 
 qc/paired/dummybfragilis_R1.fastq.gz
 qc/paired/dummybfragilis_R2.fastq.gz
 qc/paired/dummyecoli_R1.fastq.gz
 qc/paired/dummyecoli_R2.fastq.gz
+qc/paired/random_R1.fastq.gz
+qc/paired/random_R2.fastq.gz
 
 mapping/human-KI270762.1.alignment.png
 mapping/phix174-gi|9626372|ref|NC_001422.1|.alignment.png


### PR DESCRIPTION
This adds a check for an empty input file for the "cap3" rule.  In that case the file is just passed along to the output, bypassing cap3.  The subsequent rules "save_intermediates" and "final_filter" are able to handle empty files already, so the assembly step should now run to completion even for samples where no contigs can be built.

For testing, this adds a third dummy fastq input pair, using arbitrary reads so that no contigs are build by IDBA-UD.  cap3 would then fail with a segmentation fault as described in #39, but bypassing it with the shell avoids that problem.