### PR TITLE
Adds rule for repeat masking of reads before Kraken classification

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -54,7 +54,7 @@ include: "rules/targets/targets.rules"
 # ---- Quality control rules
 include: "rules/qc/qc.rules"
 include: "rules/qc/decontaminate.rules"
-
+include: "rules/qc/repeat_masking.rules"
 
 # ---- Assembly rules
 include: "rules/assembly/assembly.rules"

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ jellyfish=1.1.11=1
 cutadapt
 pysam
 pandas
+trf

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,4 @@ jellyfish=1.1.11=1
 cutadapt
 pysam
 pandas
-trf
+repeatmasker

--- a/rules/classify/kraken.rules
+++ b/rules/classify/kraken.rules
@@ -43,7 +43,7 @@ rule kraken_classify:
         --db {Cfg[classify][kraken_db_fp]} \
         --threads {threads} \
         --paired \
-        --fastq-input \
+        --fasta-input \
         {input.r1} {input.r2} > {output}
         """
 

--- a/rules/classify/kraken.rules
+++ b/rules/classify/kraken.rules
@@ -31,8 +31,7 @@ rule classic_biom:
         
 rule kraken_classify:
     input:
-        r1=str(QC_FP/'masked'/'{sample}_R1.masked.fasta'),
-        r2=str(QC_FP/'masked'/'{sample}_R2.masked.fasta')
+        str(QC_FP/'masked'/'{sample}.fasta')
     output:
         str(CLASSIFY_FP/'kraken'/'raw'/'{sample}-raw.tsv')
     threads:
@@ -42,9 +41,8 @@ rule kraken_classify:
         kraken \
         --db {Cfg[classify][kraken_db_fp]} \
         --threads {threads} \
-        --paired \
         --fasta-input \
-        {input.r1} {input.r2} > {output}
+        {input} > {output}
         """
 
 rule kraken_report:

--- a/rules/classify/kraken.rules
+++ b/rules/classify/kraken.rules
@@ -31,8 +31,8 @@ rule classic_biom:
         
 rule kraken_classify:
     input:
-        r1=str(QC_FP/'decontam'/'{sample}_R1.fastq'),
-        r2=str(QC_FP/'decontam'/'{sample}_R2.fastq')
+        r1=str(QC_FP/'masked'/'{sample}_R1.fasta'),
+        r2=str(QC_FP/'masked'/'{sample}_R2.fasta')
     output:
         str(CLASSIFY_FP/'kraken'/'raw'/'{sample}-raw.tsv')
     threads:

--- a/rules/classify/kraken.rules
+++ b/rules/classify/kraken.rules
@@ -31,8 +31,8 @@ rule classic_biom:
         
 rule kraken_classify:
     input:
-        r1=str(QC_FP/'masked'/'{sample}_R1.fasta'),
-        r2=str(QC_FP/'masked'/'{sample}_R2.fasta')
+        r1=str(QC_FP/'masked'/'{sample}_R1.masked.fasta'),
+        r2=str(QC_FP/'masked'/'{sample}_R2.masked.fasta')
     output:
         str(CLASSIFY_FP/'kraken'/'raw'/'{sample}-raw.tsv')
     threads:

--- a/rules/qc/decontaminate.rules
+++ b/rules/qc/decontaminate.rules
@@ -9,10 +9,6 @@ rule all_decontam:
     input:
         TARGET_DECONTAM
 
-rule gunzip:
-    input: "{filename}.fastq.gz"
-    output: temp("{filename}.fastq")
-    shell: "gunzip -c {input} > {output}"
 
 rule decontam_human:
     input:
@@ -72,3 +68,8 @@ rule decontam:
         ln -s {input.r1} {output.r1}
         ln -s {input.r2} {output.r2}
         """
+
+rule gunzip:
+    input: "{filename}.fastq.gz"
+    output: temp("{filename}.fastq")
+    shell: "gunzip -c {input} > {output}"

--- a/rules/qc/repeat_masking.rules
+++ b/rules/qc/repeat_masking.rules
@@ -6,10 +6,18 @@ rule all_mask:
     input:
         TARGET_MASK
 
+rule fq2fa:
+    input:
+        str(QC_FP/'decontam'/'{filename}.fastq')
+    output:
+        temp(str(QC_FP/'masked'/'{filename}.fasta'))
+    shell:
+        "fq2fa {input} {output}"
+          
 rule dustmasker:
     input:
-        r1 = str(QC_FP/'decontam'/'{sample}_R1.fastq'),
-        r2 = str(QC_FP/'decontam'/'{sample}_R2.fastq')
+        r1 = str(QC_FP/'masked'/'{sample}_R1.fasta'),
+        r2 = str(QC_FP/'masked'/'{sample}_R2.fasta')
     output:
         r1 = temp(str(QC_FP/'masked'/'{sample}_R1.dust.fasta')),
         r2 = temp(str(QC_FP/'masked'/'{sample}_R2.dust.fasta'))

--- a/rules/qc/repeat_masking.rules
+++ b/rules/qc/repeat_masking.rules
@@ -39,8 +39,8 @@ rule trf:
         r1 = str(QC_FP/'masked'/'log'/'{sample}_R1.log'),
         r2 = str(QC_FP/'masked'/'log'/'{sample}_R2.log')
     params:
-        basename_r1 = '{sample}_R1.dust.fasta',
-        basename_r2 = '{sample}_R2.dust.fasta'
+        basename_r1 = '{sample}_R1.fasta',
+        basename_r2 = '{sample}_R2.fasta'
     shell:
         """
         trf {input.r1} 2 3 5 75 20 33 6 -m -h -ngs > {log.r1} &&
@@ -54,8 +54,8 @@ rule remove_newlines:
         r1 = str(QC_FP/'masked'/'trf'/'{sample}_R1.fasta'),
         r2 = str(QC_FP/'masked'/'trf'/'{sample}_R2.fasta')
     output:
-        r1 = str(QC_FP/'masked'/'{sample}_R1.fasta'),
-        r2 = str(QC_FP/'masked'/'{sample}_R2.fasta')
+        r1 = str(QC_FP/'masked'/'{sample}_R1.masked.fasta'),
+        r2 = str(QC_FP/'masked'/'{sample}_R2.masked.fasta')
     shell:
         """
         sed '/^$/d' {input.r1} > {output.r1} &&\

--- a/rules/qc/repeat_masking.rules
+++ b/rules/qc/repeat_masking.rules
@@ -36,7 +36,8 @@ rule repeatmasker:
         RepeatMasker -qq -no_is -pa {threads} -e hmmer -dir {params.dir} {input}
         if [[ -s {params.dir}/{wildcards.sample}.fasta.masked ]]; then
             mv {params.dir}/{wildcards.sample}.fasta.masked {output[1]}
-        else 
+        else
+            cp {input} {output[0]}x
             touch {output[1]}
         fi
         """

--- a/rules/qc/repeat_masking.rules
+++ b/rules/qc/repeat_masking.rules
@@ -19,8 +19,8 @@ rule dustmasker:
         r1 = str(QC_FP/'decontam'/'{sample}_R1.fasta'),
         r2 = str(QC_FP/'decontam'/'{sample}_R2.fasta')
     output:
-        r1 = temp(str(QC_FP/'masked'/'{sample}_R1.dust.fasta')),
-        r2 = temp(str(QC_FP/'masked'/'{sample}_R2.dust.fasta'))
+        r1 = temp(str(QC_FP/'masked'/'dust'/'{sample}_R1.fasta')),
+        r2 = temp(str(QC_FP/'masked'/'dust'/'{sample}_R2.fasta'))
     shell: """
     dustmasker -in {input.r1} -outfmt fasta |\
     sed '/>/!s/a\|c\|g\|t/N/g' > {output.r1} &&\
@@ -30,11 +30,11 @@ rule dustmasker:
 
 rule trf:
     input:
-        r1 = str(QC_FP/'masked'/'{sample}_R1.dust.fasta'),
-        r2 = str(QC_FP/'masked'/'{sample}_R2.dust.fasta')
+        r1 = str(QC_FP/'masked'/'dust'/'{sample}_R1.fasta'),
+        r2 = str(QC_FP/'masked'/'dust'/'{sample}_R2.fasta')
     output:
-        r1 = temp(str(QC_FP/'masked'/'{sample}_R1.trf.fasta')),
-        r2 = temp(str(QC_FP/'masked'/'{sample}_R2.trf.fasta'))
+        r1 = temp(str(QC_FP/'masked'/'trf'/'{sample}_R1.fasta')),
+        r2 = temp(str(QC_FP/'masked'/'trf'/'{sample}_R2.fasta'))
     log:
         r1 = str(QC_FP/'masked'/'log'/'{sample}_R1.log'),
         r2 = str(QC_FP/'masked'/'log'/'{sample}_R2.log')
@@ -51,8 +51,8 @@ rule trf:
 
 rule remove_newlines:
     input:
-        r1 = str(QC_FP/'masked'/'{sample}_R1.trf.fasta'),
-        r2 = str(QC_FP/'masked'/'{sample}_R2.trf.fasta')
+        r1 = str(QC_FP/'masked'/'trf'/'{sample}_R1.fasta'),
+        r2 = str(QC_FP/'masked'/'trf'/'{sample}_R2.fasta')
     output:
         r1 = str(QC_FP/'masked'/'{sample}_R1.fasta'),
         r2 = str(QC_FP/'masked'/'{sample}_R2.fasta')

--- a/rules/qc/repeat_masking.rules
+++ b/rules/qc/repeat_masking.rules
@@ -16,18 +16,16 @@ rule all_mask:
           
 rule dustmasker:
     input:
-        r1 = str(QC_FP/'decontam'/'{sample}_R1.fastq'),
-        r2 = str(QC_FP/'decontam'/'{sample}_R2.fastq')
+        r1 = str(QC_FP/'decontam'/'{sample}_R1.fasta'),
+        r2 = str(QC_FP/'decontam'/'{sample}_R2.fasta')
     output:
         r1 = temp(str(QC_FP/'masked'/'dust'/'{sample}_R1.fasta')),
         r2 = temp(str(QC_FP/'masked'/'dust'/'{sample}_R2.fasta'))
     shell:
         """
-        awk '{{if(NR%4==1) {{printf(">%s\n",substr($0,2));}} else if(NR%4==2) print;}} {input.r1} |\'
-        dustmasker -outfmt fasta |\
+        dustmasker -in {input.r1} -outfmt fasta |\
         sed '/>/!s/a\|c\|g\|t/N/g' > {output.r1} &&\
-        awk '{{if(NR%4==1) {{printf(">%s\n",substr($0,2));}} else if(NR%4==2) print;}} {input.r2} |\'
-        dustmasker -outfmt fasta |\
+        dustmasker -in {input.r2} -outfmt fasta |\
         sed '/>/!s/a\|c\|g\|t/N/g' > {output.r2}
         """
 

--- a/rules/qc/repeat_masking.rules
+++ b/rules/qc/repeat_masking.rules
@@ -28,7 +28,7 @@ rule repeatmasker:
     params:
         dir = str(QC_FP/'masked'/'log')
     log:
-        str(QC_FP/'masked'/'log'/'{sample}.fasta.out')
+        str(QC_FP/'masked'/'log'/'{sample}.fasta.out'),
         str(QC_FP/'masked'/'log'/'{sample}.fasta.tbl')
     shell:
         """

--- a/rules/qc/repeat_masking.rules
+++ b/rules/qc/repeat_masking.rules
@@ -5,62 +5,70 @@
 rule all_mask:
     input:
         TARGET_MASK
-
-# rule fq2fa:
-#     input:
-#         str(QC_FP/'decontam'/'{filename}.fastq')
-#     output:
-#         temp(str(QC_FP/'decontam'/'{filename}.fasta'))
-#     shell:
-#         "fq2fa {input} {output}"
           
 rule dustmasker:
     input:
-        r1 = str(QC_FP/'decontam'/'{sample}_R1.fasta'),
-        r2 = str(QC_FP/'decontam'/'{sample}_R2.fasta')
+        str(ASSEMBLY_FP/'paired'/'{sample}.fasta'),
     output:
-        r1 = temp(str(QC_FP/'masked'/'dust'/'{sample}_R1.fasta')),
-        r2 = temp(str(QC_FP/'masked'/'dust'/'{sample}_R2.fasta'))
+        temp(str(QC_FP/'masked'/'{sample}.fasta.dust'))
     shell:
         """
-        dustmasker -in {input.r1} -outfmt fasta |\
-        sed '/>/!s/a\|c\|g\|t/N/g' > {output.r1} &&\
-        dustmasker -in {input.r2} -outfmt fasta |\
-        sed '/>/!s/a\|c\|g\|t/N/g' > {output.r2}
+        dustmasker -in {input} -outfmt fasta |\
+        sed '/>/!s/a\|c\|g\|t/N/g' > {output}
         """
 
-rule trf:
+rule repeatmasker:
     input:
-        r1 = str(QC_FP/'masked'/'dust'/'{sample}_R1.fasta'),
-        r2 = str(QC_FP/'masked'/'dust'/'{sample}_R2.fasta')
+        str(QC_FP/'masked'/'{sample}.fasta.dust')
     output:
-        r1 = temp(str(QC_FP/'masked'/'trf'/'{sample}_R1.fasta')),
-        r2 = temp(str(QC_FP/'masked'/'trf'/'{sample}_R2.fasta'))
-    log:
-        r1 = str(QC_FP/'masked'/'log'/'{sample}_R1.log'),
-        r2 = str(QC_FP/'masked'/'log'/'{sample}_R2.log')
+        str(QC_FP/'masked'/'{sample}.fasta')
+        tmp(str(QC_FP/'masked'/'log'/'{sample}.fasta.cat'))
+    threads:
+        Cfg['qc']['threads']
     params:
-        basename_r1 = '{sample}_R1.fasta',
-        basename_r2 = '{sample}_R2.fasta'
+        dir = str(QC_FP/'masked'/'log')
+    log:
+        str(QC_FP/'masked'/'log'/'{sample}.fasta.out')
+        str(QC_FP/'masked'/'log'/'{sample}.fasta.tbl')
     shell:
         """
-        trf {input.r1} 2 3 5 75 20 33 6 -m -h -ngs > {log.r1} &&
-        mv {params.basename_r1}.2.3.5.75.20.33.6.mask {output.r1} &&
-        trf {input.r2} 2 3 5 75 20 33 6 -m -h -ngs > {log.r2} &&
-        mv {params.basename_r2}.2.3.5.75.20.33.6.mask {output.r2}
+        mkdir -p {params.dir} &&\
+        RepeatMasker -qq -no_is -pa {threads} -e hmmer -dir {params.dir} {input} &&\
+        mv {params.dir}/{wildcards.sample}.fasta.masked} {output[1]}
         """
+          
+# rule trf:
+#     input:
+#         r1 = str(QC_FP/'masked'/'dust'/'{sample}_R1.fasta'),
+#         r2 = str(QC_FP/'masked'/'dust'/'{sample}_R2.fasta')
+#     output:
+#         r1 = temp(str(QC_FP/'masked'/'trf'/'{sample}_R1.fasta')),
+#         r2 = temp(str(QC_FP/'masked'/'trf'/'{sample}_R2.fasta'))
+#     log:
+#         r1 = str(QC_FP/'masked'/'log'/'{sample}_R1.log'),
+#         r2 = str(QC_FP/'masked'/'log'/'{sample}_R2.log')
+#     params:
+#         basename_r1 = '{sample}_R1.fasta',
+#         basename_r2 = '{sample}_R2.fasta'
+#     shell:
+#         """
+#         trf {input.r1} 2 3 5 75 20 33 6 -m -h -ngs > {log.r1} &&
+#         mv {params.basename_r1}.2.3.5.75.20.33.6.mask {output.r1} &&
+#         trf {input.r2} 2 3 5 75 20 33 6 -m -h -ngs > {log.r2} &&
+#         mv {params.basename_r2}.2.3.5.75.20.33.6.mask {output.r2}
+#         """
 
-rule remove_newlines:
-    input:
-        r1 = str(QC_FP/'masked'/'trf'/'{sample}_R1.fasta'),
-        r2 = str(QC_FP/'masked'/'trf'/'{sample}_R2.fasta')
-    output:
-        r1 = str(QC_FP/'masked'/'{sample}_R1.masked.fasta'),
-        r2 = str(QC_FP/'masked'/'{sample}_R2.masked.fasta')
-    shell:
-        """
-        sed '/^$/d' {input.r1} > {output.r1} &&\
-        sed '/^$/d' {input.r2} > {output.r2}
-        """
+# rule remove_newlines:
+#     input:
+#         r1 = str(QC_FP/'masked'/'trf'/'{sample}_R1.fasta'),
+#         r2 = str(QC_FP/'masked'/'trf'/'{sample}_R2.fasta')
+#     output:
+#         r1 = str(QC_FP/'masked'/'{sample}_R1.masked.fasta'),
+#         r2 = str(QC_FP/'masked'/'{sample}_R2.masked.fasta')
+#     shell:
+#         """
+#         sed '/^$/d' {input.r1} > {output.r1} &&\
+#         sed '/^$/d' {input.r2} > {output.r2}
+#         """
            
            

--- a/rules/qc/repeat_masking.rules
+++ b/rules/qc/repeat_masking.rules
@@ -22,7 +22,7 @@ rule repeatmasker:
         str(QC_FP/'masked'/'{sample}.fasta.dust')
     output:
         str(QC_FP/'masked'/'{sample}.fasta'),
-    threads:
+        temp(str(QC_FP/'masked'/'log'/'{sample}.fasta.cat'))
     threads:
         Cfg['qc']['threads']
     params:

--- a/rules/qc/repeat_masking.rules
+++ b/rules/qc/repeat_masking.rules
@@ -22,7 +22,7 @@ rule repeatmasker:
         str(QC_FP/'masked'/'{sample}.fasta.dust')
     output:
         str(QC_FP/'masked'/'{sample}.fasta'),
-        tmp(str(QC_FP/'masked'/'log'/'{sample}.fasta.cat'))
+    threads:
     threads:
         Cfg['qc']['threads']
     params:

--- a/rules/qc/repeat_masking.rules
+++ b/rules/qc/repeat_masking.rules
@@ -6,13 +6,13 @@ rule all_mask:
     input:
         TARGET_MASK
 
-rule fq2fa:
-    input:
-        str(QC_FP/'decontam'/'{filename}.fastq')
-    output:
-        temp(str(QC_FP/'decontam'/'{filename}.fasta'))
-    shell:
-        "fq2fa {input} {output}"
+# rule fq2fa:
+#     input:
+#         str(QC_FP/'decontam'/'{filename}.fastq')
+#     output:
+#         temp(str(QC_FP/'decontam'/'{filename}.fasta'))
+#     shell:
+#         "fq2fa {input} {output}"
           
 rule dustmasker:
     input:

--- a/rules/qc/repeat_masking.rules
+++ b/rules/qc/repeat_masking.rules
@@ -27,7 +27,7 @@ rule repeatmasker:
         Cfg['qc']['threads']
     params:
         dir = str(QC_FP/'masked'/'log'),
-        skip = Cfg['qc']['mask_reads'] if 'mask_reads' in Cfg['qc'].keys() else False
+        skip = Cfg['qc'].get('skip_complexity_masking', False)
     log:
         str(QC_FP/'masked'/'log'/'{sample}.fasta.out'),
         str(QC_FP/'masked'/'log'/'{sample}.fasta.tbl')

--- a/rules/qc/repeat_masking.rules
+++ b/rules/qc/repeat_masking.rules
@@ -37,7 +37,7 @@ rule repeatmasker:
         if [[ -s {params.dir}/{wildcards.sample}.fasta.masked ]]; then
             mv {params.dir}/{wildcards.sample}.fasta.masked {output[1]}
         else
-            cp {input} {output[0]}x
+            cp {input} {output[0]}
             touch {output[1]}
         fi
         """

--- a/rules/qc/repeat_masking.rules
+++ b/rules/qc/repeat_masking.rules
@@ -21,7 +21,7 @@ rule repeatmasker:
     input:
         str(QC_FP/'masked'/'{sample}.fasta.dust')
     output:
-        str(QC_FP/'masked'/'{sample}.fasta')
+        str(QC_FP/'masked'/'{sample}.fasta'),
         tmp(str(QC_FP/'masked'/'log'/'{sample}.fasta.cat'))
     threads:
         Cfg['qc']['threads']

--- a/rules/qc/repeat_masking.rules
+++ b/rules/qc/repeat_masking.rules
@@ -10,14 +10,14 @@ rule fq2fa:
     input:
         str(QC_FP/'decontam'/'{filename}.fastq')
     output:
-        temp(str(QC_FP/'masked'/'{filename}.fasta'))
+        temp(str(QC_FP/'decontam'/'{filename}.fasta'))
     shell:
         "fq2fa {input} {output}"
           
 rule dustmasker:
     input:
-        r1 = str(QC_FP/'masked'/'{sample}_R1.fasta'),
-        r2 = str(QC_FP/'masked'/'{sample}_R2.fasta')
+        r1 = str(QC_FP/'decontam'/'{sample}_R1.fasta'),
+        r2 = str(QC_FP/'decontam'/'{sample}_R2.fasta')
     output:
         r1 = temp(str(QC_FP/'masked'/'{sample}_R1.dust.fasta')),
         r2 = temp(str(QC_FP/'masked'/'{sample}_R2.dust.fasta'))

--- a/rules/qc/repeat_masking.rules
+++ b/rules/qc/repeat_masking.rules
@@ -33,8 +33,13 @@ rule repeatmasker:
     shell:
         """
         mkdir -p {params.dir} &&\
-        RepeatMasker -qq -no_is -pa {threads} -e hmmer -dir {params.dir} {input} &&\
-        mv {params.dir}/{wildcards.sample}.fasta.masked {output[1]}
+        RepeatMasker -qq -no_is -pa {threads} -e hmmer -dir {params.dir} {input}
+        if [[ -s {params.dir}/{wildcards.sample}.fasta.masked ]]; then
+            mv {params.dir}/{wildcards.sample}.fasta.masked {output[1]}
+        else 
+            ln -s {input} {output[0]}
+            touch {output[1]}
+        fi
         """
           
 # rule trf:

--- a/rules/qc/repeat_masking.rules
+++ b/rules/qc/repeat_masking.rules
@@ -1,0 +1,44 @@
+# -*- mode: Snakemake -*-
+#
+# Rules to mask low-complexity regions and short repeats
+
+rule all_mask:
+    input:
+        TARGET_MASK
+
+rule dustmasker:
+    input:
+        r1 = str(QC_FP/'decontam'/'{sample}_R1.fastq'),
+        r2 = str(QC_FP/'decontam'/'{sample}_R2.fastq')
+    output:
+        r1 = temp(str(QC_FP/'masked'/'{sample}_R1.dust.fasta')),
+        r2 = temp(str(QC_FP/'masked'/'{sample}_R2.dust.fasta'))
+    shell: """
+    dustmasker -in {input.r1} -outfmt fasta |\
+    sed '/>/!s/a\|c\|g\|t/N/g' > {output.r1} &&\
+    dustmasker -in {input.r2} -outfmt fasta |\
+    sed '/>/!s/a\|c\|g\|t/N/g' > {output.r2}
+    """
+
+rule trf:
+    input:
+        r1 = str(QC_FP/'masked'/'{sample}_R1.dust.fasta'),
+        r2 = str(QC_FP/'masked'/'{sample}_R2.dust.fasta')
+    output:
+        r1 = str(QC_FP/'masked'/'{sample}_R1.fasta'),
+        r2 = str(QC_FP/'masked'/'{sample}_R2.fasta')
+    log:
+        r1 = str(QC_FP/'masked'/'log'/'{sample}_R1.log'),
+        r2 = str(QC_FP/'masked'/'log'/'{sample}_R2.log')
+    params:
+        basename_r1 = '{sample}_R1.dust.fasta',
+        basename_r2 = '{sample}_R2.dust.fasta'
+    shell:
+        """
+        trf {input.r1} 2 3 5 75 20 33 6 -m -h -ngs > {log.r1} &&
+        mv {params.basename_r1}.2.3.5.75.20.33.6.mask {output.r1} &&
+        trf {input.r2} 2 3 5 75 20 33 6 -m -h -ngs > {log.r2} &&
+        mv {params.basename_r2}.2.3.5.75.20.33.6.mask {output.r2}
+        """
+
+        

--- a/rules/qc/repeat_masking.rules
+++ b/rules/qc/repeat_masking.rules
@@ -34,7 +34,7 @@ rule repeatmasker:
         """
         mkdir -p {params.dir} &&\
         RepeatMasker -qq -no_is -pa {threads} -e hmmer -dir {params.dir} {input} &&\
-        mv {params.dir}/{wildcards.sample}.fasta.masked} {output[1]}
+        mv {params.dir}/{wildcards.sample}.fasta.masked {output[1]}
         """
           
 # rule trf:

--- a/rules/qc/repeat_masking.rules
+++ b/rules/qc/repeat_masking.rules
@@ -26,21 +26,32 @@ rule repeatmasker:
     threads:
         Cfg['qc']['threads']
     params:
-        dir = str(QC_FP/'masked'/'log')
+        dir = str(QC_FP/'masked'/'log'),
+        skip = Cfg['qc']['mask_reads'] if 'mask_reads' in Cfg['qc'].keys() else False
     log:
         str(QC_FP/'masked'/'log'/'{sample}.fasta.out'),
         str(QC_FP/'masked'/'log'/'{sample}.fasta.tbl')
-    shell:
-        """
-        mkdir -p {params.dir} &&\
-        RepeatMasker -qq -no_is -pa {threads} -e hmmer -dir {params.dir} {input}
-        if [[ -s {params.dir}/{wildcards.sample}.fasta.masked ]]; then
-            mv {params.dir}/{wildcards.sample}.fasta.masked {output[1]}
-        else
-            cp {input} {output[0]}
-            touch {output[1]}
-        fi
-        """
+    run:
+        if params.skip:
+            shell(
+                """
+                cp {input} {output[0]}
+                touch {output[1]}
+                """
+            )
+        else:
+            shell(
+                """
+                mkdir -p {params.dir} &&\
+                RepeatMasker -qq -no_is -pa {threads} -e hmmer -dir {params.dir} {input}
+                    if [[ -s {params.dir}/{wildcards.sample}.fasta.masked ]]; then
+                    mv {params.dir}/{wildcards.sample}.fasta.masked {output[1]}
+                else
+                    cp {input} {output[0]}
+                    touch {output[1]}
+                fi
+                """
+            )
           
 # rule trf:
 #     input:

--- a/rules/qc/repeat_masking.rules
+++ b/rules/qc/repeat_masking.rules
@@ -33,8 +33,8 @@ rule trf:
         r1 = str(QC_FP/'masked'/'{sample}_R1.dust.fasta'),
         r2 = str(QC_FP/'masked'/'{sample}_R2.dust.fasta')
     output:
-        r1 = str(QC_FP/'masked'/'{sample}_R1.fasta'),
-        r2 = str(QC_FP/'masked'/'{sample}_R2.fasta')
+        r1 = temp(str(QC_FP/'masked'/'{sample}_R1.trf.fasta')),
+        r2 = temp(str(QC_FP/'masked'/'{sample}_R2.trf.fasta'))
     log:
         r1 = str(QC_FP/'masked'/'log'/'{sample}_R1.log'),
         r2 = str(QC_FP/'masked'/'log'/'{sample}_R2.log')
@@ -49,4 +49,17 @@ rule trf:
         mv {params.basename_r2}.2.3.5.75.20.33.6.mask {output.r2}
         """
 
-        
+rule remove_newlines:
+    input:
+        r1 = str(QC_FP/'masked'/'{sample}_R1.trf.fasta'),
+        r2 = str(QC_FP/'masked'/'{sample}_R2.trf.fasta')
+    output:
+        r1 = str(QC_FP/'masked'/'{sample}_R1.fasta'),
+        r2 = str(QC_FP/'masked'/'{sample}_R2.fasta')
+    shell:
+        """
+        sed '/^$/d' {input.r1} > {output.r1} &&\
+        sed '/^$/d' {input.r2} > {output.r2}
+        """
+           
+           

--- a/rules/qc/repeat_masking.rules
+++ b/rules/qc/repeat_masking.rules
@@ -37,7 +37,6 @@ rule repeatmasker:
         if [[ -s {params.dir}/{wildcards.sample}.fasta.masked ]]; then
             mv {params.dir}/{wildcards.sample}.fasta.masked {output[1]}
         else 
-            ln -s {input} {output[0]}
             touch {output[1]}
         fi
         """

--- a/rules/qc/repeat_masking.rules
+++ b/rules/qc/repeat_masking.rules
@@ -16,17 +16,20 @@ rule all_mask:
           
 rule dustmasker:
     input:
-        r1 = str(QC_FP/'decontam'/'{sample}_R1.fasta'),
-        r2 = str(QC_FP/'decontam'/'{sample}_R2.fasta')
+        r1 = str(QC_FP/'decontam'/'{sample}_R1.fastq'),
+        r2 = str(QC_FP/'decontam'/'{sample}_R2.fastq')
     output:
         r1 = temp(str(QC_FP/'masked'/'dust'/'{sample}_R1.fasta')),
         r2 = temp(str(QC_FP/'masked'/'dust'/'{sample}_R2.fasta'))
-    shell: """
-    dustmasker -in {input.r1} -outfmt fasta |\
-    sed '/>/!s/a\|c\|g\|t/N/g' > {output.r1} &&\
-    dustmasker -in {input.r2} -outfmt fasta |\
-    sed '/>/!s/a\|c\|g\|t/N/g' > {output.r2}
-    """
+    shell:
+        """
+        awk '{{if(NR%4==1) {{printf(">%s\n",substr($0,2));}} else if(NR%4==2) print;}} {input.r1} |\'
+        dustmasker -outfmt fasta |\
+        sed '/>/!s/a\|c\|g\|t/N/g' > {output.r1} &&\
+        awk '{{if(NR%4==1) {{printf(">%s\n",substr($0,2));}} else if(NR%4==2) print;}} {input.r2} |\'
+        dustmasker -outfmt fasta |\
+        sed '/>/!s/a\|c\|g\|t/N/g' > {output.r2}
+        """
 
 rule trf:
     input:

--- a/rules/targets/targets.rules
+++ b/rules/targets/targets.rules
@@ -13,7 +13,7 @@ TARGET_QC = expand(str(QC_FP/'paired'/'{sample}_{rp}_fastqc/fastqc_data.txt'), s
 TARGET_DECONTAM = expand(str(QC_FP/'decontam'/'{sample}_{rp}.fastq'), sample = Samples.keys(), rp = ['R1', 'R2'])
 
 ### Mask low-complexity sequences
-TARGET_MASK = expand(str(QC_FP/'masked'/'{sample}_{rp}.fasta'), sample = Samples.keys(), rp = ['R1', 'R2'])
+TARGET_MASK = expand(str(QC_FP/'masked'/'{sample}_{rp}.masked.fasta'), sample = Samples.keys(), rp = ['R1', 'R2'])
 
 ####################
 ## classify

--- a/rules/targets/targets.rules
+++ b/rules/targets/targets.rules
@@ -12,6 +12,9 @@ TARGET_QC = expand(str(QC_FP/'paired'/'{sample}_{rp}_fastqc/fastqc_data.txt'), s
 ### Remove host reads
 TARGET_DECONTAM = expand(str(QC_FP/'decontam'/'{sample}_{rp}.fastq'), sample = Samples.keys(), rp = ['R1', 'R2'])
 
+### Mask low-complexity sequences
+TARGET_MASK = expand(str(QC_FP/'masked'/'{sample}_{rp}.fasta'), sample = Samples.keys(), rp = ['R1', 'R2'])
+
 ####################
 ## classify
 ####################

--- a/rules/targets/targets.rules
+++ b/rules/targets/targets.rules
@@ -12,8 +12,10 @@ TARGET_QC = expand(str(QC_FP/'paired'/'{sample}_{rp}_fastqc/fastqc_data.txt'), s
 ### Remove host reads
 TARGET_DECONTAM = expand(str(QC_FP/'decontam'/'{sample}_{rp}.fastq'), sample = Samples.keys(), rp = ['R1', 'R2'])
 
-### Mask low-complexity sequences
-TARGET_MASK = expand(str(QC_FP/'masked'/'{sample}_{rp}.masked.fasta'), sample = Samples.keys(), rp = ['R1', 'R2'])
+### Mask low-complexity and repeat sequences
+TARGET_MASK = expand(
+    str(QC_FP/'masked'/'{sample}.fasta'),
+    sample = Samples.keys())
 
 ####################
 ## classify


### PR DESCRIPTION
Uses RepeatFinder to mask repetitive sequences before Kraken classification. This reduces false-positive identifications, especially when working with the RefSeq genomic database on PMACs.

RepeatFinder is really slow, however, so this is an expensive process. It would be better if this was optional or possibly maintained on a separate branch. @kylebittinger @ressy @zhaoc1 can we discuss before merging? Maybe we don't want this merged in but just kept up-to-date with the master branch?