### PR TITLE
custom_removal should not be a local rule

### DIFF
--- a/rules/qc/qc.rules
+++ b/rules/qc/qc.rules
@@ -2,8 +2,6 @@
 #
 # Illumina quality control rules
 
-localrules: custom_removal
-
 rule all_qc:
     """Runs trimmomatic and fastqc on all input files."""
     input:


### PR DESCRIPTION
* [ ] I have run `bash tests/test.sh` on a local deployment and the tests passed successfully
* [ ] If this adds a new output file, I have added a check to tests/targets.txt
* [ ] If this fixes a bug, I have added an appropriate test to tests/test.sh
* [ ] If this adds or modifies a rule that uses FASTQ files, the input accepts gzipped FASTQ and outputs gzipped FASTQ, or marks uncompressed FASTQ output as `temp`
